### PR TITLE
Adjust feature layout and update Korean trust copy

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -89,7 +89,7 @@ footer p{ margin:3px 0; }
   font-size:38px;
   font-weight:700;
   color:var(--primary-blue);
-  margin:0 0 8px;
+  margin:0;
 }
 .header p{
   font-size:17px;
@@ -101,7 +101,7 @@ footer p{ margin:3px 0; }
   display:flex;
   flex-direction:column;
   align-items:center;
-  gap:6px;
+  gap:3px;
   text-align:center;
 }
 
@@ -289,9 +289,9 @@ footer p{ margin:3px 0; }
 }
 
 .highlight-card{
-  background:linear-gradient(135deg,rgba(50,100,255,.08),rgba(255,255,255,.65));
-  border:1px solid rgba(50,100,255,.18);
-  box-shadow:0 18px 40px rgba(50,100,255,.12);
+  background:rgba(255,255,255,.94);
+  border:1px solid rgba(255,255,255,.55);
+  box-shadow:0 15px 40px rgba(15,23,42,.08);
 }
 
 .highlight-card h2{

--- a/en/index.html
+++ b/en/index.html
@@ -88,27 +88,6 @@
 
     <div class="link-list" id="results"></div>
 
-    <section class="feature-section">
-      <h2 data-lang="featureTitle">🚀 Why creators love it</h2>
-      <div class="feature-grid">
-        <article class="feature-card">
-          <span class="feature-icon" aria-hidden="true">⏱️</span>
-          <h3 data-lang="featureSpeedTitle">Ready in 3 seconds</h3>
-          <p data-lang="featureSpeedDesc">Drop in a link and instantly generate comparison URLs across 21 regions.</p>
-        </article>
-        <article class="feature-card">
-          <span class="feature-icon" aria-hidden="true">🎯</span>
-          <h3 data-lang="featureAutomationTitle">Auto affiliate tags</h3>
-          <p data-lang="featureAutomationDesc">Country-specific discount codes and partner parameters are added for you.</p>
-        </article>
-        <article class="feature-card">
-          <span class="feature-icon" aria-hidden="true">🌏</span>
-          <h3 data-lang="featureLanguageTitle">Built for global teams</h3>
-          <p data-lang="featureLanguageDesc">Switch the UI across Korean, English, Japanese, and Thai for effortless sharing.</p>
-        </article>
-      </div>
-    </section>
-
     <div class="info-grid">
       <section class="info-card usage-card">
         <div class="card-header">
@@ -145,6 +124,27 @@
         </p>
       </section>
     </div>
+
+    <section class="feature-section">
+      <h2 data-lang="featureTitle">🚀 Why creators love it</h2>
+      <div class="feature-grid">
+        <article class="feature-card">
+          <span class="feature-icon" aria-hidden="true">⏱️</span>
+          <h3 data-lang="featureSpeedTitle">Ready in 3 seconds</h3>
+          <p data-lang="featureSpeedDesc">Drop in a link and instantly generate comparison URLs across 21 regions.</p>
+        </article>
+        <article class="feature-card">
+          <span class="feature-icon" aria-hidden="true">🎯</span>
+          <h3 data-lang="featureAutomationTitle">Auto affiliate tags</h3>
+          <p data-lang="featureAutomationDesc">Country-specific discount codes and partner parameters are added for you.</p>
+        </article>
+        <article class="feature-card">
+          <span class="feature-icon" aria-hidden="true">🌏</span>
+          <h3 data-lang="featureLanguageTitle">Built for global teams</h3>
+          <p data-lang="featureLanguageDesc">Switch the UI across Korean, English, Japanese, and Thai for effortless sharing.</p>
+        </article>
+      </div>
+    </section>
 
     <section class="trust-panel">
       <div class="trust-copy">

--- a/i18n/translations.js
+++ b/i18n/translations.js
@@ -83,8 +83,8 @@ window.TRANSLATIONS = {
     youtube:"YouTube", blog:"Blog",
     redirecting:"트립닷컴으로 이동합니다...",
 
-    trustTitle:"여행 준비 시간을 더 아껴보세요",
-    trustDesc:"트립닷닷은 기획자와 메이커가 직접 만든 초간단 가격 비교 도구예요. 복잡한 표 대신 버튼만 눌러보세요.",
+    trustTitle:"여행 비용을 더 아껴보세요",
+    trustDesc:"트립닷닷을 통해 할인받아 구매한 금액이 1억을 넘었어요 !",
     trustMetricCountries:"21+",
     trustMetricLinks:"1클릭",
     trustMetricMinutes:"10+",

--- a/index.html
+++ b/index.html
@@ -90,27 +90,6 @@
 
     <div class="link-list" id="results"></div>
 
-    <section class="feature-section">
-      <h2 data-lang="featureTitle">🚀 이런 점이 좋아요</h2>
-      <div class="feature-grid">
-        <article class="feature-card">
-          <span class="feature-icon" aria-hidden="true">⏱️</span>
-          <h3 data-lang="featureSpeedTitle">3초면 준비 끝</h3>
-          <p data-lang="featureSpeedDesc">링크를 붙여넣는 순간 21개국 가격 비교 링크가 자동 생성돼요.</p>
-        </article>
-        <article class="feature-card">
-          <span class="feature-icon" aria-hidden="true">🎯</span>
-          <h3 data-lang="featureAutomationTitle">할인코드 자동 적용</h3>
-          <p data-lang="featureAutomationDesc">국가별로 다른 할인 코드와 제휴 파라미터를 알아서 붙여줘요.</p>
-        </article>
-        <article class="feature-card">
-          <span class="feature-icon" aria-hidden="true">🌏</span>
-          <h3 data-lang="featureLanguageTitle">다국어 완전 지원</h3>
-          <p data-lang="featureLanguageDesc">한국어, 영어, 일본어, 태국어 UI로 누구나 쉽게 공유할 수 있어요.</p>
-        </article>
-      </div>
-    </section>
-
     <div class="info-grid">
       <section class="info-card usage-card">
         <div class="card-header">
@@ -148,10 +127,31 @@
       </section>
     </div>
 
+    <section class="feature-section">
+      <h2 data-lang="featureTitle">🚀 이런 점이 좋아요</h2>
+      <div class="feature-grid">
+        <article class="feature-card">
+          <span class="feature-icon" aria-hidden="true">⏱️</span>
+          <h3 data-lang="featureSpeedTitle">3초면 준비 끝</h3>
+          <p data-lang="featureSpeedDesc">링크를 붙여넣는 순간 21개국 가격 비교 링크가 자동 생성돼요.</p>
+        </article>
+        <article class="feature-card">
+          <span class="feature-icon" aria-hidden="true">🎯</span>
+          <h3 data-lang="featureAutomationTitle">할인코드 자동 적용</h3>
+          <p data-lang="featureAutomationDesc">국가별로 다른 할인 코드와 제휴 파라미터를 알아서 붙여줘요.</p>
+        </article>
+        <article class="feature-card">
+          <span class="feature-icon" aria-hidden="true">🌏</span>
+          <h3 data-lang="featureLanguageTitle">다국어 완전 지원</h3>
+          <p data-lang="featureLanguageDesc">한국어, 영어, 일본어, 태국어 UI로 누구나 쉽게 공유할 수 있어요.</p>
+        </article>
+      </div>
+    </section>
+
     <section class="trust-panel">
       <div class="trust-copy">
-        <h2 data-lang="trustTitle">여행 준비 시간을 더 아껴보세요</h2>
-        <p data-lang="trustDesc">트립닷닷은 기획자와 메이커가 직접 만든 초간단 가격 비교 도구예요. 복잡한 표 대신 버튼만 눌러보세요.</p>
+        <h2 data-lang="trustTitle">여행 비용을 더 아껴보세요</h2>
+        <p data-lang="trustDesc">트립닷닷을 통해 할인받아 구매한 금액이 1억을 넘었어요 !</p>
       </div>
       <div class="trust-metrics" role="list">
         <div class="trust-metric" role="listitem">

--- a/ja/index.html
+++ b/ja/index.html
@@ -108,27 +108,6 @@
 
     <div class="link-list" id="results"></div>
 
-    <section class="feature-section">
-      <h2 data-lang="featureTitle">🚀 Tripdotdot の魅力</h2>
-      <div class="feature-grid">
-        <article class="feature-card">
-          <span class="feature-icon" aria-hidden="true">⏱️</span>
-          <h3 data-lang="featureSpeedTitle">3秒で準備完了</h3>
-          <p data-lang="featureSpeedDesc">リンクを貼り付けるだけで21地域の比較リンクが即座に生成されます。</p>
-        </article>
-        <article class="feature-card">
-          <span class="feature-icon" aria-hidden="true">🎯</span>
-          <h3 data-lang="featureAutomationTitle">割引コードも自動付与</h3>
-          <p data-lang="featureAutomationDesc">国ごとに異なるディスカウントコードとパートナーパラメータを自動で適用します。</p>
-        </article>
-        <article class="feature-card">
-          <span class="feature-icon" aria-hidden="true">🌏</span>
-          <h3 data-lang="featureLanguageTitle">グローバルに共有</h3>
-          <p data-lang="featureLanguageDesc">韓国語・英語・日本語・タイ語のUIにワンクリックで切り替えられます。</p>
-        </article>
-      </div>
-    </section>
-
     <div class="info-grid">
       <section class="info-card usage-card">
         <div class="card-header">
@@ -171,6 +150,27 @@
         </p>
       </section>
     </div>
+
+    <section class="feature-section">
+      <h2 data-lang="featureTitle">🚀 Tripdotdot の魅力</h2>
+      <div class="feature-grid">
+        <article class="feature-card">
+          <span class="feature-icon" aria-hidden="true">⏱️</span>
+          <h3 data-lang="featureSpeedTitle">3秒で準備完了</h3>
+          <p data-lang="featureSpeedDesc">リンクを貼り付けるだけで21地域の比較リンクが即座に生成されます。</p>
+        </article>
+        <article class="feature-card">
+          <span class="feature-icon" aria-hidden="true">🎯</span>
+          <h3 data-lang="featureAutomationTitle">割引コードも自動付与</h3>
+          <p data-lang="featureAutomationDesc">国ごとに異なるディスカウントコードとパートナーパラメータを自動で適用します。</p>
+        </article>
+        <article class="feature-card">
+          <span class="feature-icon" aria-hidden="true">🌏</span>
+          <h3 data-lang="featureLanguageTitle">グローバルに共有</h3>
+          <p data-lang="featureLanguageDesc">韓国語・英語・日本語・タイ語のUIにワンクリックで切り替えられます。</p>
+        </article>
+      </div>
+    </section>
 
     <section class="trust-panel">
       <div class="trust-copy">

--- a/th/index.html
+++ b/th/index.html
@@ -88,27 +88,6 @@
 
     <div class="link-list" id="results"></div>
 
-    <section class="feature-section">
-      <h2 data-lang="featureTitle">🚀 จุดเด่นของ Tripdotdot</h2>
-      <div class="feature-grid">
-        <article class="feature-card">
-          <span class="feature-icon" aria-hidden="true">⏱️</span>
-          <h3 data-lang="featureSpeedTitle">พร้อมใช้ใน 3 วินาที</h3>
-          <p data-lang="featureSpeedDesc">วางลิงก์แล้วรับลิงก์เปรียบเทียบ 21 ประเทศทันที</p>
-        </article>
-        <article class="feature-card">
-          <span class="feature-icon" aria-hidden="true">🎯</span>
-          <h3 data-lang="featureAutomationTitle">ผูกโค้ดส่วนลดอัตโนมัติ</h3>
-          <p data-lang="featureAutomationDesc">ระบบใส่โค้ดส่วนลดและพารามิเตอร์พาร์ทเนอร์ให้ตามแต่ละประเทศ</p>
-        </article>
-        <article class="feature-card">
-          <span class="feature-icon" aria-hidden="true">🌏</span>
-          <h3 data-lang="featureLanguageTitle">แชร์ได้หลายภาษา</h3>
-          <p data-lang="featureLanguageDesc">สลับ UI ได้ทั้งเกาหลี อังกฤษ ญี่ปุ่น และไทย เพื่อทำงานร่วมกับทีมต่างประเทศ</p>
-        </article>
-      </div>
-    </section>
-
     <div class="info-grid">
       <section class="info-card usage-card">
         <div class="card-header">
@@ -145,6 +124,27 @@
         </p>
       </section>
     </div>
+
+    <section class="feature-section">
+      <h2 data-lang="featureTitle">🚀 จุดเด่นของ Tripdotdot</h2>
+      <div class="feature-grid">
+        <article class="feature-card">
+          <span class="feature-icon" aria-hidden="true">⏱️</span>
+          <h3 data-lang="featureSpeedTitle">พร้อมใช้ใน 3 วินาที</h3>
+          <p data-lang="featureSpeedDesc">วางลิงก์แล้วรับลิงก์เปรียบเทียบ 21 ประเทศทันที</p>
+        </article>
+        <article class="feature-card">
+          <span class="feature-icon" aria-hidden="true">🎯</span>
+          <h3 data-lang="featureAutomationTitle">ผูกโค้ดส่วนลดอัตโนมัติ</h3>
+          <p data-lang="featureAutomationDesc">ระบบใส่โค้ดส่วนลดและพารามิเตอร์พาร์ทเนอร์ให้ตามแต่ละประเทศ</p>
+        </article>
+        <article class="feature-card">
+          <span class="feature-icon" aria-hidden="true">🌏</span>
+          <h3 data-lang="featureLanguageTitle">แชร์ได้หลายภาษา</h3>
+          <p data-lang="featureLanguageDesc">สลับ UI ได้ทั้งเกาหลี อังกฤษ ญี่ปุ่น และไทย เพื่อทำงานร่วมกับทีมต่างประเทศ</p>
+        </article>
+      </div>
+    </section>
 
     <section class="trust-panel">
       <div class="trust-copy">


### PR DESCRIPTION
## Summary
- reduce the hero heading spacing and align the highlight card background with other info cards
- reposition the feature highlight section so it sits directly above the trust panel on every locale page
- refresh the Korean trust banner copy to emphasize cost savings

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ea831e05f483318eb427914e8bbae9