### PR TITLE
Adjust mobile language selector placement

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -458,6 +458,12 @@ footer p{ margin:3px 0; }
   .feature-section{ padding:28px 24px; }
   .trust-panel{ padding:28px 24px; }
 }
+
+@media (max-width:480px){
+  .language-selector{ top:14px; right:14px; }
+  .language-button{ padding:5px 10px; }
+  .language-button #lang-text{ font-size:14px; }
+}
 .external-link-btn:focus-visible{ outline:none; box-shadow:0 0 0 3px var(--light-blue); }
 
 /* 플랫폼 전용 색상 유지 */

--- a/en/index.html
+++ b/en/index.html
@@ -62,16 +62,16 @@
 <body>
   <div class="container">
     <header class="header">
-      <div class="language-selector">
-        <button id="language-button" class="language-button" aria-haspopup="true" aria-expanded="false">
-          <img id="lang-flag" src="" alt="Language flag">
-          <span id="lang-text"></span><span class="dropdown-arrow">▼</span>
-        </button>
-        <div id="language-dropdown" class="language-dropdown" role="menu">
-        </div>
-      </div>
-
       <div class="hero-surface">
+        <div class="language-selector">
+          <button id="language-button" class="language-button" aria-haspopup="true" aria-expanded="false">
+            <img id="lang-flag" src="" alt="Language flag">
+            <span id="lang-text"></span><span class="dropdown-arrow">▼</span>
+          </button>
+          <div id="language-dropdown" class="language-dropdown" role="menu">
+          </div>
+        </div>
+
         <div class="hero-copy">
           <h1 data-lang="mainTitle">🌐 Tripdotdot</h1>
           <p class="hero-subtitle" data-lang="subtitle">Trip.com Lowest Price Link Finder</p>

--- a/index.html
+++ b/index.html
@@ -63,17 +63,17 @@
 <body>
   <div class="container">
     <header class="header">
-      <div class="language-selector">
-        <button id="language-button" class="language-button" aria-haspopup="true" aria-expanded="false">
-          <img id="lang-flag" src="" alt="Language flag">
-          <span id="lang-text"></span>
-          <span class="dropdown-arrow">▼</span>
-        </button>
-        <div id="language-dropdown" class="language-dropdown" role="menu">
-        </div>
-      </div>
-
       <div class="hero-surface">
+        <div class="language-selector">
+          <button id="language-button" class="language-button" aria-haspopup="true" aria-expanded="false">
+            <img id="lang-flag" src="" alt="Language flag">
+            <span id="lang-text"></span>
+            <span class="dropdown-arrow">▼</span>
+          </button>
+          <div id="language-dropdown" class="language-dropdown" role="menu">
+          </div>
+        </div>
+
         <div class="hero-copy">
           <h1 data-lang="mainTitle">🌐 트립닷닷</h1>
           <p class="hero-subtitle" data-lang="subtitle">트립닷컴 최저가 링크 찾기</p>

--- a/ja/index.html
+++ b/ja/index.html
@@ -82,15 +82,15 @@
 <body>
   <div class="container">
     <header class="header">
-      <nav class="language-selector" aria-label="Language selector">
-        <button id="language-button" class="language-button" aria-haspopup="true" aria-expanded="false">
-          <img id="lang-flag" src="" alt="Language flag" width="24" height="16" loading="lazy" decoding="async">
-          <span id="lang-text"></span><span class="dropdown-arrow" aria-hidden="true">▼</span>
-        </button>
-        <div id="language-dropdown" class="language-dropdown" role="menu"></div>
-      </nav>
-
       <div class="hero-surface">
+        <nav class="language-selector" aria-label="Language selector">
+          <button id="language-button" class="language-button" aria-haspopup="true" aria-expanded="false">
+            <img id="lang-flag" src="" alt="Language flag" width="24" height="16" loading="lazy" decoding="async">
+            <span id="lang-text"></span><span class="dropdown-arrow" aria-hidden="true">▼</span>
+          </button>
+          <div id="language-dropdown" class="language-dropdown" role="menu"></div>
+        </nav>
+
         <div class="hero-copy">
           <h1 data-lang="mainTitle">🌐 トリップドットドット（Tripdotdot）</h1>
           <p class="hero-subtitle" data-lang="subtitle">Trip.com 最安値リンク検索｜トリップドットドット</p>

--- a/th/index.html
+++ b/th/index.html
@@ -62,16 +62,16 @@
 <body>
   <div class="container">
     <header class="header">
-      <div class="language-selector">
-        <button id="language-button" class="language-button" aria-haspopup="true" aria-expanded="false">
-          <img id="lang-flag" src="" alt="Language flag">
-          <span id="lang-text"></span>
-          <span class="dropdown-arrow">▼</span>
-        </button>
-        <div id="language-dropdown" class="language-dropdown" role="menu"></div>
-      </div>
-
       <div class="hero-surface">
+        <div class="language-selector">
+          <button id="language-button" class="language-button" aria-haspopup="true" aria-expanded="false">
+            <img id="lang-flag" src="" alt="Language flag">
+            <span id="lang-text"></span>
+            <span class="dropdown-arrow">▼</span>
+          </button>
+          <div id="language-dropdown" class="language-dropdown" role="menu"></div>
+        </div>
+
         <div class="hero-copy">
           <h1 data-lang="mainTitle">🌐 Tripdotdot</h1>
           <p class="hero-subtitle" data-lang="subtitle">ค้นหาลิงก์ราคาถูกสุดของ Trip.com</p>


### PR DESCRIPTION
## Summary
- move the language selector into the hero surface on each locale so the control sits within the white card on mobile
- tweak mobile spacing for the selector and button so it remains aligned on small screens

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ec78552abc83319ac7276afa88df3d