### PR TITLE
Add Google AdSense verification script to static pages

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -8,6 +8,9 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7NKHHET1CP"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-7NKHHET1CP');</script>
 
+  <!-- Google AdSense -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6227921544579562" crossorigin="anonymous"></script>
+
   <!-- Microsoft Clarity -->
   <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window,document,"clarity","script","sd3i2hqjuv");</script>
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,9 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7NKHHET1CP"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-7NKHHET1CP');</script>
 
+  <!-- Google AdSense -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6227921544579562" crossorigin="anonymous"></script>
+
   <!-- Microsoft Clarity -->
   <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window,document,"clarity","script","sd3i2hqjuv");</script>
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -46,6 +46,7 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date()); gtag('config','G-7NKHHET1CP');
   </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6227921544579562" crossorigin="anonymous"></script>
   <script>
     (function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)}
     ;t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i

--- a/privacy_en.html
+++ b/privacy_en.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <title>Privacy Policy - Tripdotdot</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Google AdSense -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6227921544579562" crossorigin="anonymous"></script>
   <meta name="robots" content="noindex, nofollow">
   <meta name="googlebot" content="noindex, nofollow">
   <style>

--- a/privacy_ja.html
+++ b/privacy_ja.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <title>プライバシーポリシー - Tripdotdot</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Google AdSense -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6227921544579562" crossorigin="anonymous"></script>
   <!-- 検索結果に表示しない -->
   <meta name="robots" content="noindex, nofollow">
   <meta name="googlebot" content="noindex, nofollow">

--- a/privacy_ko.html
+++ b/privacy_ko.html
@@ -6,6 +6,8 @@
   <meta name="robots" content="noindex, nofollow">
   <meta name="googlebot" content="noindex, nofollow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Google AdSense -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6227921544579562" crossorigin="anonymous"></script>
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;

--- a/privacy_th.html
+++ b/privacy_th.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <title>นโยบายความเป็นส่วนตัว - Tripdotdot</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Google AdSense -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6227921544579562" crossorigin="anonymous"></script>
   <!-- ไม่ให้ปรากฏในผลการค้นหา -->
   <meta name="robots" content="noindex, nofollow">
   <style>

--- a/th/index.html
+++ b/th/index.html
@@ -8,6 +8,9 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7NKHHET1CP"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-7NKHHET1CP');</script>
 
+  <!-- Google AdSense -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6227921544579562" crossorigin="anonymous"></script>
+
   <!-- Microsoft Clarity -->
   <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window,document,"clarity","script","sd3i2hqjuv");</script>
 


### PR DESCRIPTION
## Summary
- add the Google AdSense verification script to each localized landing page
- include the AdSense script on every privacy policy page so verification can read them as well

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_690b43c1d3fc8331b6b019af0a31c4c3