### PR TITLE
Add desktop-only AdSense slot to localized landing pages

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -79,6 +79,19 @@ body::after{
   flex-direction:column;
   gap:32px;
 }
+.desktop-ad-slot{
+  display:none;
+}
+@media (min-width:1024px){
+  .desktop-ad-slot{
+    display:flex;
+    justify-content:center;
+  }
+  .desktop-ad-slot .adsbygoogle{
+    width:100%;
+    max-width:728px;
+  }
+}
 footer p{ margin:3px 0; }
 
 .header{

--- a/en/index.html
+++ b/en/index.html
@@ -91,6 +91,37 @@
 
     <div class="link-list" id="results"></div>
 
+    <div class="desktop-ad-slot" aria-label="Advertisement">
+      <ins class="adsbygoogle"
+           style="display:block"
+           data-ad-format="autorelaxed"
+           data-ad-client="ca-pub-6227921544579562"
+           data-ad-slot="6082799445"></ins>
+      <script>
+        (function() {
+          var mq = window.matchMedia('(min-width: 1024px)');
+          function loadAd(e){
+            if (e.matches) {
+              (adsbygoogle = window.adsbygoogle || []).push({});
+              if (typeof mq.removeEventListener === 'function') {
+                mq.removeEventListener('change', loadAd);
+              } else if (typeof mq.removeListener === 'function') {
+                mq.removeListener(loadAd);
+              }
+            }
+          }
+          loadAd(mq);
+          if (!mq.matches) {
+            if (typeof mq.addEventListener === 'function') {
+              mq.addEventListener('change', loadAd);
+            } else if (typeof mq.addListener === 'function') {
+              mq.addListener(loadAd);
+            }
+          }
+        })();
+      </script>
+    </div>
+
     <div class="info-grid">
       <section class="info-card usage-card">
         <div class="card-header">

--- a/index.html
+++ b/index.html
@@ -93,6 +93,37 @@
 
     <div class="link-list" id="results"></div>
 
+    <div class="desktop-ad-slot" aria-label="광고 영역">
+      <ins class="adsbygoogle"
+           style="display:block"
+           data-ad-format="autorelaxed"
+           data-ad-client="ca-pub-6227921544579562"
+           data-ad-slot="6082799445"></ins>
+      <script>
+        (function() {
+          var mq = window.matchMedia('(min-width: 1024px)');
+          function loadAd(e){
+            if (e.matches) {
+              (adsbygoogle = window.adsbygoogle || []).push({});
+              if (typeof mq.removeEventListener === 'function') {
+                mq.removeEventListener('change', loadAd);
+              } else if (typeof mq.removeListener === 'function') {
+                mq.removeListener(loadAd);
+              }
+            }
+          }
+          loadAd(mq);
+          if (!mq.matches) {
+            if (typeof mq.addEventListener === 'function') {
+              mq.addEventListener('change', loadAd);
+            } else if (typeof mq.addListener === 'function') {
+              mq.addListener(loadAd);
+            }
+          }
+        })();
+      </script>
+    </div>
+
     <div class="info-grid">
       <section class="info-card usage-card">
         <div class="card-header">

--- a/ja/index.html
+++ b/ja/index.html
@@ -109,6 +109,37 @@
 
     <div class="link-list" id="results"></div>
 
+    <div class="desktop-ad-slot" aria-label="広告エリア">
+      <ins class="adsbygoogle"
+           style="display:block"
+           data-ad-format="autorelaxed"
+           data-ad-client="ca-pub-6227921544579562"
+           data-ad-slot="6082799445"></ins>
+      <script>
+        (function() {
+          var mq = window.matchMedia('(min-width: 1024px)');
+          function loadAd(e){
+            if (e.matches) {
+              (adsbygoogle = window.adsbygoogle || []).push({});
+              if (typeof mq.removeEventListener === 'function') {
+                mq.removeEventListener('change', loadAd);
+              } else if (typeof mq.removeListener === 'function') {
+                mq.removeListener(loadAd);
+              }
+            }
+          }
+          loadAd(mq);
+          if (!mq.matches) {
+            if (typeof mq.addEventListener === 'function') {
+              mq.addEventListener('change', loadAd);
+            } else if (typeof mq.addListener === 'function') {
+              mq.addListener(loadAd);
+            }
+          }
+        })();
+      </script>
+    </div>
+
     <div class="info-grid">
       <section class="info-card usage-card">
         <div class="card-header">

--- a/th/index.html
+++ b/th/index.html
@@ -91,6 +91,37 @@
 
     <div class="link-list" id="results"></div>
 
+    <div class="desktop-ad-slot" aria-label="พื้นที่โฆษณา">
+      <ins class="adsbygoogle"
+           style="display:block"
+           data-ad-format="autorelaxed"
+           data-ad-client="ca-pub-6227921544579562"
+           data-ad-slot="6082799445"></ins>
+      <script>
+        (function() {
+          var mq = window.matchMedia('(min-width: 1024px)');
+          function loadAd(e){
+            if (e.matches) {
+              (adsbygoogle = window.adsbygoogle || []).push({});
+              if (typeof mq.removeEventListener === 'function') {
+                mq.removeEventListener('change', loadAd);
+              } else if (typeof mq.removeListener === 'function') {
+                mq.removeListener(loadAd);
+              }
+            }
+          }
+          loadAd(mq);
+          if (!mq.matches) {
+            if (typeof mq.addEventListener === 'function') {
+              mq.addEventListener('change', loadAd);
+            } else if (typeof mq.addListener === 'function') {
+              mq.addListener(loadAd);
+            }
+          }
+        })();
+      </script>
+    </div>
+
     <div class="info-grid">
       <section class="info-card usage-card">
         <div class="card-header">


### PR DESCRIPTION
## Summary
- embed a Google AdSense auto-relaxed ad slot in each localized landing page and initialize it only for desktop viewports
- add responsive styling so the new ad placement is hidden on smaller screens and centered with a max width on desktop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690b4f8a923c833199eb25deae2a3d0d