### PR TITLE
Add AdSense card to info grid on localized homepages

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -267,6 +267,15 @@ footer p{ margin:3px 0; }
   box-shadow:0 15px 40px rgba(15,23,42,.08);
   border:1px solid rgba(255,255,255,.55);
 }
+.ad-card{
+  padding:0;
+  min-height:280px;
+  overflow:hidden;
+}
+.ad-card .adsbygoogle{
+  width:100%;
+  display:block !important;
+}
 .card-header{
   display:flex; justify-content:space-between; align-items:center;
   margin-bottom:16px; padding-bottom:12px; border-bottom:1px solid var(--border-color);

--- a/en/index.html
+++ b/en/index.html
@@ -126,6 +126,17 @@
           💰 Always compare the <strong>final price</strong> including taxes/fees.
         </p>
       </section>
+
+      <section class="info-card ad-card" aria-label="Advertisement">
+        <ins class="adsbygoogle"
+             style="display:block"
+             data-ad-format="autorelaxed"
+             data-ad-client="ca-pub-6227921544579562"
+             data-ad-slot="6082799445"></ins>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
+      </section>
     </div>
 
     <section class="feature-section">

--- a/index.html
+++ b/index.html
@@ -130,6 +130,17 @@
           💰 <strong>세금/수수료 포함</strong> 금액으로 비교하세요
         </p>
       </section>
+
+      <section class="info-card ad-card" aria-label="광고">
+        <ins class="adsbygoogle"
+             style="display:block"
+             data-ad-format="autorelaxed"
+             data-ad-client="ca-pub-6227921544579562"
+             data-ad-slot="6082799445"></ins>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
+      </section>
     </div>
 
     <section class="feature-section">

--- a/ja/index.html
+++ b/ja/index.html
@@ -150,6 +150,17 @@
           💰 税金/手数料込みの<strong>「最終金額」</strong>で比較してください。
         </p>
       </section>
+
+      <section class="info-card ad-card" aria-label="広告">
+        <ins class="adsbygoogle"
+             style="display:block"
+             data-ad-format="autorelaxed"
+             data-ad-client="ca-pub-6227921544579562"
+             data-ad-slot="6082799445"></ins>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
+      </section>
     </div>
 
     <section class="feature-section">

--- a/th/index.html
+++ b/th/index.html
@@ -126,6 +126,17 @@
           💰 เทียบ<strong>“ราคารวมสุดท้าย”</strong>ที่รวมภาษี/ค่าธรรมเนียมแล้ว
         </p>
       </section>
+
+      <section class="info-card ad-card" aria-label="โฆษณา">
+        <ins class="adsbygoogle"
+             style="display:block"
+             data-ad-format="autorelaxed"
+             data-ad-client="ca-pub-6227921544579562"
+             data-ad-slot="6082799445"></ins>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
+      </section>
     </div>
 
     <section class="feature-section">


### PR DESCRIPTION
## Summary
- add an AdSense ad card to the info grid on the Korean, English, Japanese, and Thai homepages
- style the new ad card so the ad fills the available space while matching existing card styling

## Testing
- not run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_690b52bd2548833189fd65d19e35b2f2