### PR TITLE
Add desktop-only AdSense block to info grid

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -267,6 +267,19 @@ footer p{ margin:3px 0; }
   box-shadow:0 15px 40px rgba(15,23,42,.08);
   border:1px solid rgba(255,255,255,.55);
 }
+.adsense-card{
+  padding:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+.adsense-card .adsense-wrapper{
+  width:100%;
+}
+.adsense-card .adsbygoogle{
+  width:100%;
+  height:100%;
+}
 .card-header{
   display:flex; justify-content:space-between; align-items:center;
   margin-bottom:16px; padding-bottom:12px; border-bottom:1px solid var(--border-color);
@@ -398,6 +411,11 @@ footer p{ margin:3px 0; }
   display:grid;
   gap:24px;
   grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+}
+.desktop-only{ display:block; }
+
+@media (max-width:768px){
+  .desktop-only{ display:none !important; }
 }
 
 /* ===== Trust Panel ===== */

--- a/en/index.html
+++ b/en/index.html
@@ -126,6 +126,20 @@
           💰 Always compare the <strong>final price</strong> including taxes/fees.
         </p>
       </section>
+
+      <section class="info-card adsense-card desktop-only" aria-label="Tripdotdot advertisement">
+        <div class="adsense-wrapper">
+          <ins class="adsbygoogle"
+               style="display:block"
+               data-ad-client="ca-pub-6227921544579562"
+               data-ad-slot="7115027120"
+               data-ad-format="auto"
+               data-full-width-responsive="true"></ins>
+        </div>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
+      </section>
     </div>
 
     <section class="feature-section">

--- a/index.html
+++ b/index.html
@@ -130,6 +130,20 @@
           💰 <strong>세금/수수료 포함</strong> 금액으로 비교하세요
         </p>
       </section>
+
+      <section class="info-card adsense-card desktop-only" aria-label="Tripdotdot 광고">
+        <div class="adsense-wrapper">
+          <ins class="adsbygoogle"
+               style="display:block"
+               data-ad-client="ca-pub-6227921544579562"
+               data-ad-slot="7115027120"
+               data-ad-format="auto"
+               data-full-width-responsive="true"></ins>
+        </div>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
+      </section>
     </div>
 
     <section class="feature-section">

--- a/ja/index.html
+++ b/ja/index.html
@@ -150,6 +150,20 @@
           💰 税金/手数料込みの<strong>「最終金額」</strong>で比較してください。
         </p>
       </section>
+
+      <section class="info-card adsense-card desktop-only" aria-label="Tripdotdot 広告">
+        <div class="adsense-wrapper">
+          <ins class="adsbygoogle"
+               style="display:block"
+               data-ad-client="ca-pub-6227921544579562"
+               data-ad-slot="7115027120"
+               data-ad-format="auto"
+               data-full-width-responsive="true"></ins>
+        </div>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
+      </section>
     </div>
 
     <section class="feature-section">

--- a/th/index.html
+++ b/th/index.html
@@ -126,6 +126,20 @@
           💰 เทียบ<strong>“ราคารวมสุดท้าย”</strong>ที่รวมภาษี/ค่าธรรมเนียมแล้ว
         </p>
       </section>
+
+      <section class="info-card adsense-card desktop-only" aria-label="Tripdotdot โฆษณา">
+        <div class="adsense-wrapper">
+          <ins class="adsbygoogle"
+               style="display:block"
+               data-ad-client="ca-pub-6227921544579562"
+               data-ad-slot="7115027120"
+               data-ad-format="auto"
+               data-full-width-responsive="true"></ins>
+        </div>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
+      </section>
     </div>
 
     <section class="feature-section">


### PR DESCRIPTION
## Summary
- add a responsive Google AdSense block to the info grid on each localized home page
- style the AdSense card to fill the grid space on desktop while hiding it on smaller screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690b6575400c83318ecc38dc722c07dd