### PR TITLE
Balance desktop info card heights with AdSense block

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -266,6 +266,25 @@ footer p{ margin:3px 0; }
   border-radius:18px;
   box-shadow:0 15px 40px rgba(15,23,42,.08);
   border:1px solid rgba(255,255,255,.55);
+  display:flex;
+  flex-direction:column;
+  height:100%;
+}
+.adsense-card{
+  padding:0;
+  align-items:center;
+  justify-content:center;
+}
+.adsense-card .adsense-wrapper{
+  width:100%;
+  height:100%;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  flex:1 1 auto;
+}
+.adsense-card .adsbygoogle{
+  width:100%;
 }
 .card-header{
   display:flex; justify-content:space-between; align-items:center;
@@ -398,6 +417,18 @@ footer p{ margin:3px 0; }
   display:grid;
   gap:24px;
   grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+}
+.desktop-only{ display:block; }
+
+@media (min-width:768px){
+  .info-grid{
+    grid-auto-rows:minmax(260px,auto);
+    align-items:stretch;
+  }
+}
+
+@media (max-width:768px){
+  .desktop-only{ display:none !important; }
 }
 
 /* ===== Trust Panel ===== */

--- a/en/index.html
+++ b/en/index.html
@@ -126,6 +126,20 @@
           💰 Always compare the <strong>final price</strong> including taxes/fees.
         </p>
       </section>
+
+      <section class="info-card adsense-card desktop-only" aria-label="Tripdotdot advertisement">
+        <div class="adsense-wrapper">
+          <ins class="adsbygoogle"
+               style="display:block"
+               data-ad-client="ca-pub-6227921544579562"
+               data-ad-slot="7115027120"
+               data-ad-format="auto"
+               data-full-width-responsive="true"></ins>
+        </div>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
+      </section>
     </div>
 
     <section class="feature-section">

--- a/index.html
+++ b/index.html
@@ -130,6 +130,20 @@
           💰 <strong>세금/수수료 포함</strong> 금액으로 비교하세요
         </p>
       </section>
+
+      <section class="info-card adsense-card desktop-only" aria-label="Tripdotdot 광고">
+        <div class="adsense-wrapper">
+          <ins class="adsbygoogle"
+               style="display:block"
+               data-ad-client="ca-pub-6227921544579562"
+               data-ad-slot="7115027120"
+               data-ad-format="auto"
+               data-full-width-responsive="true"></ins>
+        </div>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
+      </section>
     </div>
 
     <section class="feature-section">

--- a/ja/index.html
+++ b/ja/index.html
@@ -150,6 +150,20 @@
           💰 税金/手数料込みの<strong>「最終金額」</strong>で比較してください。
         </p>
       </section>
+
+      <section class="info-card adsense-card desktop-only" aria-label="Tripdotdot 広告">
+        <div class="adsense-wrapper">
+          <ins class="adsbygoogle"
+               style="display:block"
+               data-ad-client="ca-pub-6227921544579562"
+               data-ad-slot="7115027120"
+               data-ad-format="auto"
+               data-full-width-responsive="true"></ins>
+        </div>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
+      </section>
     </div>
 
     <section class="feature-section">

--- a/th/index.html
+++ b/th/index.html
@@ -126,6 +126,20 @@
           💰 เทียบ<strong>“ราคารวมสุดท้าย”</strong>ที่รวมภาษี/ค่าธรรมเนียมแล้ว
         </p>
       </section>
+
+      <section class="info-card adsense-card desktop-only" aria-label="Tripdotdot โฆษณา">
+        <div class="adsense-wrapper">
+          <ins class="adsbygoogle"
+               style="display:block"
+               data-ad-client="ca-pub-6227921544579562"
+               data-ad-slot="7115027120"
+               data-ad-format="auto"
+               data-full-width-responsive="true"></ins>
+        </div>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
+      </section>
     </div>
 
     <section class="feature-section">


### PR DESCRIPTION
## Summary
- make info cards stretch to the full grid row height so the desktop AdSense tile no longer towers over its neighbor
- center the AdSense iframe inside its card and only apply the matching row height behavior on desktop widths

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690b6575400c83318ecc38dc722c07dd