### PR TITLE
Update ad guide popup content across locales

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -240,47 +240,47 @@
   <script>
     const popupTexts = {
       ko: {
-        logo: "트립닷닷",
+        logo: "🌐 트립닷닷",
         title: "사용법",
         button: "확인했어요",
         steps: [
-          "Trip.com에서 원하는 호텔/항공 상품 선택",
-          "해당 상품 주소창 링크 복사",
-          "트립닷닷 입력창에 링크 붙여넣기",
-          "‘최저가 링크 찾기’ 클릭"
+          "Trip.com에서 <strong>원하는 호텔/항공 상품 선택</strong>",
+          "해당 상품 주소창 <strong>링크 복사</strong>",
+          "트립닷닷 입력창에 <strong>링크 붙여넣기</strong>",
+          "‘<strong>최저가 링크 찾기</strong>’ 클릭"
         ]
       },
       ja: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "使い方",
         button: "OK",
         steps: [
-          "Trip.comで宿泊/航空ページを開く",
-          "そのページのURLをコピーする",
-          "Tripdotdotの入力欄に貼り付ける",
-          "「最安値リンクを探す」をクリック"
+          "Trip.comで<strong>宿泊/航空ページを開く</strong>",
+          "そのページのURLを<strong>コピーする</strong>",
+          "Tripdotdotの入力欄に<strong>貼り付ける</strong>",
+          "「<strong>最安値リンクを探す</strong>」をクリック"
         ]
       },
       th: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "วิธีใช้",
         button: "เข้าใจแล้ว",
         steps: [
-          "เปิดหน้าโรงแรม/ตั๋วเครื่องบินใน Trip.com",
-          "คัดลอกลิงก์ (URL) ของหน้านั้น",
-          "วางลิงก์ในช่องของ Tripdotdot",
-          "กด “ค้นหาลิงก์ราคาต่ำสุด”"
+          "ใน Trip.com <strong>เปิดหน้าโรงแรม/ตั๋วเครื่องบิน</strong>",
+          "<strong>คัดลอกลิงก์ (URL)</strong> ของหน้านั้น",
+          "ที่ Tripdotdot <strong>วางลิงก์</strong>",
+          "กด “<strong>ค้นหาลิงก์ราคาต่ำสุด</strong>”"
         ]
       },
       en: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "How to use",
         button: "Got it",
         steps: [
-          "Open the hotel/flight page on Trip.com",
-          "Copy the page URL from the address bar",
-          "Paste the URL into Tripdotdot",
-          "Click “Find lowest price”"
+          "On Trip.com, <strong>choose your hotel/flight</strong>",
+          "<strong>Copy the link</strong> from the address bar",
+          "In Tripdotdot, <strong>paste the link</strong>",
+          "Click “<strong>Find lowest price</strong>”"
         ]
       }
     };
@@ -312,7 +312,12 @@
         num.className = "num";
         num.textContent = (idx + 1).toString();
         li.appendChild(num);
-        li.appendChild(document.createTextNode(txt));
+
+        const textSpan = document.createElement("span");
+        textSpan.className = "step-text";
+        textSpan.innerHTML = txt;
+        li.appendChild(textSpan);
+
         list.appendChild(li);
       });
     }

--- a/index.html
+++ b/index.html
@@ -244,47 +244,47 @@
   <script>
     const popupTexts = {
       ko: {
-        logo: "트립닷닷",
+        logo: "🌐 트립닷닷",
         title: "사용법",
         button: "확인했어요",
         steps: [
-          "Trip.com에서 원하는 호텔/항공 상품 선택",
-          "해당 상품 주소창 링크 복사",
-          "트립닷닷 입력창에 링크 붙여넣기",
-          "‘최저가 링크 찾기’ 클릭"
+          "Trip.com에서 <strong>원하는 호텔/항공 상품 선택</strong>",
+          "해당 상품 주소창 <strong>링크 복사</strong>",
+          "트립닷닷 입력창에 <strong>링크 붙여넣기</strong>",
+          "‘<strong>최저가 링크 찾기</strong>’ 클릭"
         ]
       },
       ja: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "使い方",
         button: "OK",
         steps: [
-          "Trip.comで宿泊/航空ページを開く",
-          "そのページのURLをコピーする",
-          "Tripdotdotの入力欄に貼り付ける",
-          "「最安値リンクを探す」をクリック"
+          "Trip.comで<strong>宿泊/航空ページを開く</strong>",
+          "そのページのURLを<strong>コピーする</strong>",
+          "Tripdotdotの入力欄に<strong>貼り付ける</strong>",
+          "「<strong>最安値リンクを探す</strong>」をクリック"
         ]
       },
       th: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "วิธีใช้",
         button: "เข้าใจแล้ว",
         steps: [
-          "เปิดหน้าโรงแรม/ตั๋วเครื่องบินใน Trip.com",
-          "คัดลอกลิงก์ (URL) ของหน้านั้น",
-          "วางลิงก์ในช่องของ Tripdotdot",
-          "กด “ค้นหาลิงก์ราคาต่ำสุด”"
+          "ใน Trip.com <strong>เปิดหน้าโรงแรม/ตั๋วเครื่องบิน</strong>",
+          "<strong>คัดลอกลิงก์ (URL)</strong> ของหน้านั้น",
+          "ที่ Tripdotdot <strong>วางลิงก์</strong>",
+          "กด “<strong>ค้นหาลิงก์ราคาต่ำสุด</strong>”"
         ]
       },
       en: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "How to use",
         button: "Got it",
         steps: [
-          "Open the hotel/flight page on Trip.com",
-          "Copy the page URL from the address bar",
-          "Paste the URL into Tripdotdot",
-          "Click “Find lowest price”"
+          "On Trip.com, <strong>choose your hotel/flight</strong>",
+          "<strong>Copy the link</strong> from the address bar",
+          "In Tripdotdot, <strong>paste the link</strong>",
+          "Click “<strong>Find lowest price</strong>”"
         ]
       }
     };
@@ -316,7 +316,12 @@
         num.className = "num";
         num.textContent = (idx + 1).toString();
         li.appendChild(num);
-        li.appendChild(document.createTextNode(txt));
+
+        const textSpan = document.createElement("span");
+        textSpan.className = "step-text";
+        textSpan.innerHTML = txt;
+        li.appendChild(textSpan);
+
         list.appendChild(li);
       });
     }

--- a/ja/index.html
+++ b/ja/index.html
@@ -265,47 +265,47 @@
   <script>
     const popupTexts = {
       ko: {
-        logo: "트립닷닷",
+        logo: "🌐 트립닷닷",
         title: "사용법",
         button: "확인했어요",
         steps: [
-          "Trip.com에서 원하는 호텔/항공 상품 선택",
-          "해당 상품 주소창 링크 복사",
-          "트립닷닷 입력창에 링크 붙여넣기",
-          "‘최저가 링크 찾기’ 클릭"
+          "Trip.com에서 <strong>원하는 호텔/항공 상품 선택</strong>",
+          "해당 상품 주소창 <strong>링크 복사</strong>",
+          "트립닷닷 입력창에 <strong>링크 붙여넣기</strong>",
+          "‘<strong>최저가 링크 찾기</strong>’ 클릭"
         ]
       },
       ja: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "使い方",
         button: "OK",
         steps: [
-          "Trip.comで宿泊/航空ページを開く",
-          "そのページのURLをコピーする",
-          "Tripdotdotの入力欄に貼り付ける",
-          "「最安値リンクを探す」をクリック"
+          "Trip.comで<strong>宿泊/航空ページを開く</strong>",
+          "そのページのURLを<strong>コピーする</strong>",
+          "Tripdotdotの入力欄に<strong>貼り付ける</strong>",
+          "「<strong>最安値リンクを探す</strong>」をクリック"
         ]
       },
       th: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "วิธีใช้",
         button: "เข้าใจแล้ว",
         steps: [
-          "เปิดหน้าโรงแรม/ตั๋วเครื่องบินใน Trip.com",
-          "คัดลอกลิงก์ (URL) ของหน้านั้น",
-          "วางลิงก์ในช่องของ Tripdotdot",
-          "กด “ค้นหาลิงก์ราคาต่ำสุด”"
+          "ใน Trip.com <strong>เปิดหน้าโรงแรม/ตั๋วเครื่องบิน</strong>",
+          "<strong>คัดลอกลิงก์ (URL)</strong> ของหน้านั้น",
+          "ที่ Tripdotdot <strong>วางลิงก์</strong>",
+          "กด “<strong>ค้นหาลิงก์ราคาต่ำสุด</strong>”"
         ]
       },
       en: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "How to use",
         button: "Got it",
         steps: [
-          "Open the hotel/flight page on Trip.com",
-          "Copy the page URL from the address bar",
-          "Paste the URL into Tripdotdot",
-          "Click “Find lowest price”"
+          "On Trip.com, <strong>choose your hotel/flight</strong>",
+          "<strong>Copy the link</strong> from the address bar",
+          "In Tripdotdot, <strong>paste the link</strong>",
+          "Click “<strong>Find lowest price</strong>”"
         ]
       }
     };
@@ -337,7 +337,12 @@
         num.className = "num";
         num.textContent = (idx + 1).toString();
         li.appendChild(num);
-        li.appendChild(document.createTextNode(txt));
+
+        const textSpan = document.createElement("span");
+        textSpan.className = "step-text";
+        textSpan.innerHTML = txt;
+        li.appendChild(textSpan);
+
         list.appendChild(li);
       });
     }

--- a/th/index.html
+++ b/th/index.html
@@ -241,47 +241,47 @@
   <script>
     const popupTexts = {
       ko: {
-        logo: "트립닷닷",
+        logo: "🌐 트립닷닷",
         title: "사용법",
         button: "확인했어요",
         steps: [
-          "Trip.com에서 원하는 호텔/항공 상품 선택",
-          "해당 상품 주소창 링크 복사",
-          "트립닷닷 입력창에 링크 붙여넣기",
-          "‘최저가 링크 찾기’ 클릭"
+          "Trip.com에서 <strong>원하는 호텔/항공 상품 선택</strong>",
+          "해당 상품 주소창 <strong>링크 복사</strong>",
+          "트립닷닷 입력창에 <strong>링크 붙여넣기</strong>",
+          "‘<strong>최저가 링크 찾기</strong>’ 클릭"
         ]
       },
       ja: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "使い方",
         button: "OK",
         steps: [
-          "Trip.comで宿泊/航空ページを開く",
-          "そのページのURLをコピーする",
-          "Tripdotdotの入力欄に貼り付ける",
-          "「最安値リンクを探す」をクリック"
+          "Trip.comで<strong>宿泊/航空ページを開く</strong>",
+          "そのページのURLを<strong>コピーする</strong>",
+          "Tripdotdotの入力欄に<strong>貼り付ける</strong>",
+          "「<strong>最安値リンクを探す</strong>」をクリック"
         ]
       },
       th: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "วิธีใช้",
         button: "เข้าใจแล้ว",
         steps: [
-          "เปิดหน้าโรงแรม/ตั๋วเครื่องบินใน Trip.com",
-          "คัดลอกลิงก์ (URL) ของหน้านั้น",
-          "วางลิงก์ในช่องของ Tripdotdot",
-          "กด “ค้นหาลิงก์ราคาต่ำสุด”"
+          "ใน Trip.com <strong>เปิดหน้าโรงแรม/ตั๋วเครื่องบิน</strong>",
+          "<strong>คัดลอกลิงก์ (URL)</strong> ของหน้านั้น",
+          "ที่ Tripdotdot <strong>วางลิงก์</strong>",
+          "กด “<strong>ค้นหาลิงก์ราคาต่ำสุด</strong>”"
         ]
       },
       en: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "How to use",
         button: "Got it",
         steps: [
-          "Open the hotel/flight page on Trip.com",
-          "Copy the page URL from the address bar",
-          "Paste the URL into Tripdotdot",
-          "Click “Find lowest price”"
+          "On Trip.com, <strong>choose your hotel/flight</strong>",
+          "<strong>Copy the link</strong> from the address bar",
+          "In Tripdotdot, <strong>paste the link</strong>",
+          "Click “<strong>Find lowest price</strong>”"
         ]
       }
     };
@@ -313,7 +313,12 @@
         num.className = "num";
         num.textContent = (idx + 1).toString();
         li.appendChild(num);
-        li.appendChild(document.createTextNode(txt));
+
+        const textSpan = document.createElement("span");
+        textSpan.className = "step-text";
+        textSpan.innerHTML = txt;
+        li.appendChild(textSpan);
+
         list.appendChild(li);
       });
     }


### PR DESCRIPTION
## Summary
- prepend the globe emoji to the ad guide popup logo text for every locale
- highlight each key instruction step with bold formatting across all translations
- render popup steps as HTML so formatting is preserved

## Testing
- No automated tests were run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e33a0993c8331b5759b9e6bae19ae)