### PR TITLE
Sync trust metrics content across locales

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -653,11 +653,24 @@ footer p{ margin:3px 0; }
   font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
 }
 
+
 .ad-guide-header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.ad-guide-heading {
+  display: flex;
+  align-items: baseline;
   gap: 6px;
-  margin-bottom: 12px;
+  font-size: 1.3rem;
+  font-weight: 700;
+  padding-bottom: 6px;
+  border-bottom: 2px solid rgba(15, 98, 254, 0.18);
+  flex: 1;
 }
 
 .ad-guide-logo {
@@ -668,6 +681,14 @@ footer p{ margin:3px 0; }
 .ad-guide-title {
   font-weight: 600;
   color: #1f2329;
+}
+
+.ad-guide-heading .ad-guide-title {
+  color: #0f172a;
+}
+
+.ad-guide-heading .ad-guide-logo {
+  margin-right: 2px;
 }
 
 .ad-guide-emoji {

--- a/en/index.html
+++ b/en/index.html
@@ -67,8 +67,10 @@
     <div class="ad-guide-overlay"></div>
     <div class="ad-guide-box">
       <div class="ad-guide-header">
-        <span class="ad-guide-logo"></span>
-        <span class="ad-guide-title"></span>
+        <div class="ad-guide-heading">
+          <span class="ad-guide-logo"></span>
+          <span class="ad-guide-title"></span>
+        </div>
         <span class="ad-guide-emoji">✈️</span>
       </div>
       <ul id="ad-guide-list" class="ad-guide-list"></ul>
@@ -178,21 +180,21 @@
 
     <section class="trust-panel">
       <div class="trust-copy">
-        <h2 data-lang="trustTitle">Save more of your planning time</h2>
-        <p data-lang="trustDesc">Tripdotdot is a maker-built shortcut for price discovery. Skip spreadsheets and tap one button to compare globally.</p>
+        <h2 data-lang="trustTitle">Save more on travel costs</h2>
+        <p data-lang="trustDesc">Tripdotdot users have unlocked over ₩100M in discounted bookings!</p>
       </div>
       <div class="trust-metrics" role="list">
         <div class="trust-metric" role="listitem">
+          <span class="metric-number" data-lang="trustMetricSavings">₩100M+</span>
+          <span class="metric-label" data-lang="trustStatSavings">Discounted booking value</span>
+        </div>
+        <div class="trust-metric" role="listitem">
+          <span class="metric-number" data-lang="trustMetricUsage">200+</span>
+          <span class="metric-label" data-lang="trustStatUsage">Bookings assisted</span>
+        </div>
+        <div class="trust-metric" role="listitem">
           <span class="metric-number" data-lang="trustMetricCountries">21+</span>
           <span class="metric-label" data-lang="trustStatCountries">Markets covered</span>
-        </div>
-        <div class="trust-metric" role="listitem">
-          <span class="metric-number" data-lang="trustMetricLinks">1-click</span>
-          <span class="metric-label" data-lang="trustStatLinks">Auto-generated links</span>
-        </div>
-        <div class="trust-metric" role="listitem">
-          <span class="metric-number" data-lang="trustMetricMinutes">10+</span>
-          <span class="metric-label" data-lang="trustStatMinutes">Minutes saved</span>
         </div>
       </div>
     </section>
@@ -240,47 +242,47 @@
   <script>
     const popupTexts = {
       ko: {
-        logo: "트립닷닷",
+        logo: "🌐 트립닷닷",
         title: "사용법",
         button: "확인했어요",
         steps: [
-          "Trip.com에서 원하는 호텔/항공 상품 선택",
-          "해당 상품 주소창 링크 복사",
-          "트립닷닷 입력창에 링크 붙여넣기",
-          "‘최저가 링크 찾기’ 클릭"
+          "Trip.com에서 <strong>원하는 호텔/항공 상품 선택</strong>",
+          "해당 상품 주소창 <strong>링크 복사</strong>",
+          "트립닷닷 입력창에 <strong>링크 붙여넣기</strong>",
+          "‘<strong>최저가 링크 찾기</strong>’ 클릭"
         ]
       },
       ja: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "使い方",
         button: "OK",
         steps: [
-          "Trip.comで宿泊/航空ページを開く",
-          "そのページのURLをコピーする",
-          "Tripdotdotの入力欄に貼り付ける",
-          "「最安値リンクを探す」をクリック"
+          "Trip.comで<strong>宿泊/航空ページを開く</strong>",
+          "そのページのURLを<strong>コピーする</strong>",
+          "Tripdotdotの入力欄に<strong>貼り付ける</strong>",
+          "「<strong>最安値リンクを探す</strong>」をクリック"
         ]
       },
       th: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "วิธีใช้",
         button: "เข้าใจแล้ว",
         steps: [
-          "เปิดหน้าโรงแรม/ตั๋วเครื่องบินใน Trip.com",
-          "คัดลอกลิงก์ (URL) ของหน้านั้น",
-          "วางลิงก์ในช่องของ Tripdotdot",
-          "กด “ค้นหาลิงก์ราคาต่ำสุด”"
+          "ใน Trip.com <strong>เปิดหน้าโรงแรม/ตั๋วเครื่องบิน</strong>",
+          "<strong>คัดลอกลิงก์ (URL)</strong> ของหน้านั้น",
+          "ที่ Tripdotdot <strong>วางลิงก์</strong>",
+          "กด “<strong>ค้นหาลิงก์ราคาต่ำสุด</strong>”"
         ]
       },
       en: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "How to use",
         button: "Got it",
         steps: [
-          "Open the hotel/flight page on Trip.com",
-          "Copy the page URL from the address bar",
-          "Paste the URL into Tripdotdot",
-          "Click “Find lowest price”"
+          "On Trip.com, <strong>choose your hotel/flight</strong>",
+          "<strong>Copy the link</strong> from the address bar",
+          "In Tripdotdot, <strong>paste the link</strong>",
+          "Click “<strong>Find lowest price</strong>”"
         ]
       }
     };
@@ -312,7 +314,12 @@
         num.className = "num";
         num.textContent = (idx + 1).toString();
         li.appendChild(num);
-        li.appendChild(document.createTextNode(txt));
+
+        const textSpan = document.createElement("span");
+        textSpan.className = "step-text";
+        textSpan.innerHTML = txt;
+        li.appendChild(textSpan);
+
         list.appendChild(li);
       });
     }

--- a/i18n/translations.js
+++ b/i18n/translations.js
@@ -34,12 +34,12 @@ window.TRANSLATIONS = {
     youtube:"YouTube", blog:"Blog",
     redirecting:"Redirecting to Trip.com...",
 
-    trustTitle:"Save more of your planning time",
-    trustDesc:"Tripdotdot is a maker-built shortcut for price discovery. Skip spreadsheets and tap one button to compare globally.",
+    trustTitle:"Save more on travel costs",
+    trustDesc:"Tripdotdot users have unlocked over ₩100M in discounted bookings!",
     trustMetricSavings:"₩100M+",
     trustMetricUsage:"200+",
     trustMetricCountries:"21+",
-    trustStatSavings:"Booking value unlocked",
+    trustStatSavings:"Discounted booking value",
     trustStatUsage:"Bookings assisted",
     trustStatCountries:"Markets covered",
 
@@ -132,8 +132,8 @@ window.TRANSLATIONS = {
     youtube:"YouTube", blog:"ブログ",
     redirecting:"Trip.comに移動します...",
 
-    trustTitle:"旅の準備時間をもっと節約",
-    trustDesc:"Tripdotdotはメイカーが作ったシンプルな比較ツールです。スプレッドシートよりボタン一つで価格比較しましょう。",
+    trustTitle:"旅費をもっと節約しましょう",
+    trustDesc:"Tripdotdotを使って割引購入した金額は累計₩100Mを突破しました！",
     trustMetricSavings:"₩100M+",
     trustMetricUsage:"200+",
     trustMetricCountries:"21+",
@@ -181,12 +181,12 @@ window.TRANSLATIONS = {
     youtube:"YouTube", blog:"บล็อก",
     redirecting:"กำลังพาไปที่ Trip.com...",
 
-    trustTitle:"ประหยัดเวลาวางแผนทริปได้มากขึ้น",
-    trustDesc:"Tripdotdot คือเครื่องมือที่เมกเกอร์ทำเพื่อชาวท่องเที่ยว กดปุ่มเดียวแทนการเทียบราคาด้วยสเปรดชีต",
+    trustTitle:"ประหยัดค่าเดินทางได้มากขึ้น",
+    trustDesc:"ยอดการจองผ่าน Tripdotdot ที่ได้รับส่วนลดรวมกันเกิน ₩100M แล้ว!",
     trustMetricSavings:"₩100M+",
     trustMetricUsage:"200+",
     trustMetricCountries:"21+",
-    trustStatSavings:"มูลค่าการจองที่ปลดล็อก",
+    trustStatSavings:"มูลค่าการจองที่ประหยัดได้",
     trustStatUsage:"จำนวนการใช้งาน",
     trustStatCountries:"ประเทศที่รองรับ",
 

--- a/index.html
+++ b/index.html
@@ -232,8 +232,10 @@
     <div class="ad-guide-overlay"></div>
     <div class="ad-guide-box">
       <div class="ad-guide-header">
-        <span class="ad-guide-logo"></span>
-        <span class="ad-guide-title"></span>
+        <div class="ad-guide-heading">
+          <span class="ad-guide-logo"></span>
+          <span class="ad-guide-title"></span>
+        </div>
         <span class="ad-guide-emoji">✈️</span>
       </div>
       <ul id="ad-guide-list" class="ad-guide-list"></ul>
@@ -244,47 +246,47 @@
   <script>
     const popupTexts = {
       ko: {
-        logo: "트립닷닷",
+        logo: "🌐 트립닷닷",
         title: "사용법",
         button: "확인했어요",
         steps: [
-          "Trip.com에서 원하는 호텔/항공 상품 선택",
-          "해당 상품 주소창 링크 복사",
-          "트립닷닷 입력창에 링크 붙여넣기",
-          "‘최저가 링크 찾기’ 클릭"
+          "Trip.com에서 <strong>원하는 호텔/항공 상품 선택</strong>",
+          "해당 상품 주소창 <strong>링크 복사</strong>",
+          "트립닷닷 입력창에 <strong>링크 붙여넣기</strong>",
+          "‘<strong>최저가 링크 찾기</strong>’ 클릭"
         ]
       },
       ja: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "使い方",
         button: "OK",
         steps: [
-          "Trip.comで宿泊/航空ページを開く",
-          "そのページのURLをコピーする",
-          "Tripdotdotの入力欄に貼り付ける",
-          "「最安値リンクを探す」をクリック"
+          "Trip.comで<strong>宿泊/航空ページを開く</strong>",
+          "そのページのURLを<strong>コピーする</strong>",
+          "Tripdotdotの入力欄に<strong>貼り付ける</strong>",
+          "「<strong>最安値リンクを探す</strong>」をクリック"
         ]
       },
       th: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "วิธีใช้",
         button: "เข้าใจแล้ว",
         steps: [
-          "เปิดหน้าโรงแรม/ตั๋วเครื่องบินใน Trip.com",
-          "คัดลอกลิงก์ (URL) ของหน้านั้น",
-          "วางลิงก์ในช่องของ Tripdotdot",
-          "กด “ค้นหาลิงก์ราคาต่ำสุด”"
+          "ใน Trip.com <strong>เปิดหน้าโรงแรม/ตั๋วเครื่องบิน</strong>",
+          "<strong>คัดลอกลิงก์ (URL)</strong> ของหน้านั้น",
+          "ที่ Tripdotdot <strong>วางลิงก์</strong>",
+          "กด “<strong>ค้นหาลิงก์ราคาต่ำสุด</strong>”"
         ]
       },
       en: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "How to use",
         button: "Got it",
         steps: [
-          "Open the hotel/flight page on Trip.com",
-          "Copy the page URL from the address bar",
-          "Paste the URL into Tripdotdot",
-          "Click “Find lowest price”"
+          "On Trip.com, <strong>choose your hotel/flight</strong>",
+          "<strong>Copy the link</strong> from the address bar",
+          "In Tripdotdot, <strong>paste the link</strong>",
+          "Click “<strong>Find lowest price</strong>”"
         ]
       }
     };
@@ -316,7 +318,12 @@
         num.className = "num";
         num.textContent = (idx + 1).toString();
         li.appendChild(num);
-        li.appendChild(document.createTextNode(txt));
+
+        const textSpan = document.createElement("span");
+        textSpan.className = "step-text";
+        textSpan.innerHTML = txt;
+        li.appendChild(textSpan);
+
         list.appendChild(li);
       });
     }

--- a/ja/index.html
+++ b/ja/index.html
@@ -86,8 +86,10 @@
     <div class="ad-guide-overlay"></div>
     <div class="ad-guide-box">
       <div class="ad-guide-header">
-        <span class="ad-guide-logo"></span>
-        <span class="ad-guide-title"></span>
+        <div class="ad-guide-heading">
+          <span class="ad-guide-logo"></span>
+          <span class="ad-guide-title"></span>
+        </div>
         <span class="ad-guide-emoji">✈️</span>
       </div>
       <ul id="ad-guide-list" class="ad-guide-list"></ul>
@@ -203,21 +205,21 @@
 
     <section class="trust-panel">
       <div class="trust-copy">
-        <h2 data-lang="trustTitle">旅の準備時間をもっと節約</h2>
-        <p data-lang="trustDesc">Tripdotdotはメイカーが作ったシンプルな比較ツールです。スプレッドシートよりボタン一つで価格比較しましょう。</p>
+        <h2 data-lang="trustTitle">旅費をもっと節約しましょう</h2>
+        <p data-lang="trustDesc">Tripdotdotを使って割引購入した金額は累計₩100Mを突破しました！</p>
       </div>
       <div class="trust-metrics" role="list">
         <div class="trust-metric" role="listitem">
+          <span class="metric-number" data-lang="trustMetricSavings">₩100M+</span>
+          <span class="metric-label" data-lang="trustStatSavings">割引購入金額</span>
+        </div>
+        <div class="trust-metric" role="listitem">
+          <span class="metric-number" data-lang="trustMetricUsage">200+</span>
+          <span class="metric-label" data-lang="trustStatUsage">利用件数</span>
+        </div>
+        <div class="trust-metric" role="listitem">
           <span class="metric-number" data-lang="trustMetricCountries">21+</span>
           <span class="metric-label" data-lang="trustStatCountries">対応国</span>
-        </div>
-        <div class="trust-metric" role="listitem">
-          <span class="metric-number" data-lang="trustMetricLinks">1クリック</span>
-          <span class="metric-label" data-lang="trustStatLinks">自動生成リンク</span>
-        </div>
-        <div class="trust-metric" role="listitem">
-          <span class="metric-number" data-lang="trustMetricMinutes">10+</span>
-          <span class="metric-label" data-lang="trustStatMinutes">節約できる時間（分）</span>
         </div>
       </div>
     </section>
@@ -265,47 +267,47 @@
   <script>
     const popupTexts = {
       ko: {
-        logo: "트립닷닷",
+        logo: "🌐 트립닷닷",
         title: "사용법",
         button: "확인했어요",
         steps: [
-          "Trip.com에서 원하는 호텔/항공 상품 선택",
-          "해당 상품 주소창 링크 복사",
-          "트립닷닷 입력창에 링크 붙여넣기",
-          "‘최저가 링크 찾기’ 클릭"
+          "Trip.com에서 <strong>원하는 호텔/항공 상품 선택</strong>",
+          "해당 상품 주소창 <strong>링크 복사</strong>",
+          "트립닷닷 입력창에 <strong>링크 붙여넣기</strong>",
+          "‘<strong>최저가 링크 찾기</strong>’ 클릭"
         ]
       },
       ja: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "使い方",
         button: "OK",
         steps: [
-          "Trip.comで宿泊/航空ページを開く",
-          "そのページのURLをコピーする",
-          "Tripdotdotの入力欄に貼り付ける",
-          "「最安値リンクを探す」をクリック"
+          "Trip.comで<strong>宿泊/航空ページを開く</strong>",
+          "そのページのURLを<strong>コピーする</strong>",
+          "Tripdotdotの入力欄に<strong>貼り付ける</strong>",
+          "「<strong>最安値リンクを探す</strong>」をクリック"
         ]
       },
       th: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "วิธีใช้",
         button: "เข้าใจแล้ว",
         steps: [
-          "เปิดหน้าโรงแรม/ตั๋วเครื่องบินใน Trip.com",
-          "คัดลอกลิงก์ (URL) ของหน้านั้น",
-          "วางลิงก์ในช่องของ Tripdotdot",
-          "กด “ค้นหาลิงก์ราคาต่ำสุด”"
+          "ใน Trip.com <strong>เปิดหน้าโรงแรม/ตั๋วเครื่องบิน</strong>",
+          "<strong>คัดลอกลิงก์ (URL)</strong> ของหน้านั้น",
+          "ที่ Tripdotdot <strong>วางลิงก์</strong>",
+          "กด “<strong>ค้นหาลิงก์ราคาต่ำสุด</strong>”"
         ]
       },
       en: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "How to use",
         button: "Got it",
         steps: [
-          "Open the hotel/flight page on Trip.com",
-          "Copy the page URL from the address bar",
-          "Paste the URL into Tripdotdot",
-          "Click “Find lowest price”"
+          "On Trip.com, <strong>choose your hotel/flight</strong>",
+          "<strong>Copy the link</strong> from the address bar",
+          "In Tripdotdot, <strong>paste the link</strong>",
+          "Click “<strong>Find lowest price</strong>”"
         ]
       }
     };
@@ -337,7 +339,12 @@
         num.className = "num";
         num.textContent = (idx + 1).toString();
         li.appendChild(num);
-        li.appendChild(document.createTextNode(txt));
+
+        const textSpan = document.createElement("span");
+        textSpan.className = "step-text";
+        textSpan.innerHTML = txt;
+        li.appendChild(textSpan);
+
         list.appendChild(li);
       });
     }

--- a/th/index.html
+++ b/th/index.html
@@ -68,8 +68,10 @@
     <div class="ad-guide-overlay"></div>
     <div class="ad-guide-box">
       <div class="ad-guide-header">
-        <span class="ad-guide-logo"></span>
-        <span class="ad-guide-title"></span>
+        <div class="ad-guide-heading">
+          <span class="ad-guide-logo"></span>
+          <span class="ad-guide-title"></span>
+        </div>
         <span class="ad-guide-emoji">✈️</span>
       </div>
       <ul id="ad-guide-list" class="ad-guide-list"></ul>
@@ -179,21 +181,21 @@
 
     <section class="trust-panel">
       <div class="trust-copy">
-        <h2 data-lang="trustTitle">ประหยัดเวลาวางแผนทริปได้มากขึ้น</h2>
-        <p data-lang="trustDesc">Tripdotdot คือเครื่องมือที่เมกเกอร์ทำเพื่อชาวท่องเที่ยว กดปุ่มเดียวแทนการเทียบราคาด้วยสเปรดชีต</p>
+        <h2 data-lang="trustTitle">ประหยัดค่าเดินทางได้มากขึ้น</h2>
+        <p data-lang="trustDesc">ยอดการจองผ่าน Tripdotdot ที่ได้รับส่วนลดรวมกันเกิน ₩100M แล้ว!</p>
       </div>
       <div class="trust-metrics" role="list">
         <div class="trust-metric" role="listitem">
+          <span class="metric-number" data-lang="trustMetricSavings">₩100M+</span>
+          <span class="metric-label" data-lang="trustStatSavings">มูลค่าการจองที่ประหยัดได้</span>
+        </div>
+        <div class="trust-metric" role="listitem">
+          <span class="metric-number" data-lang="trustMetricUsage">200+</span>
+          <span class="metric-label" data-lang="trustStatUsage">จำนวนการใช้งาน</span>
+        </div>
+        <div class="trust-metric" role="listitem">
           <span class="metric-number" data-lang="trustMetricCountries">21+</span>
           <span class="metric-label" data-lang="trustStatCountries">ประเทศที่รองรับ</span>
-        </div>
-        <div class="trust-metric" role="listitem">
-          <span class="metric-number" data-lang="trustMetricLinks">1 คลิก</span>
-          <span class="metric-label" data-lang="trustStatLinks">ลิงก์ที่สร้างให้อัตโนมัติ</span>
-        </div>
-        <div class="trust-metric" role="listitem">
-          <span class="metric-number" data-lang="trustMetricMinutes">10+</span>
-          <span class="metric-label" data-lang="trustStatMinutes">เวลาที่ประหยัด (นาที)</span>
         </div>
       </div>
     </section>
@@ -241,47 +243,47 @@
   <script>
     const popupTexts = {
       ko: {
-        logo: "트립닷닷",
+        logo: "🌐 트립닷닷",
         title: "사용법",
         button: "확인했어요",
         steps: [
-          "Trip.com에서 원하는 호텔/항공 상품 선택",
-          "해당 상품 주소창 링크 복사",
-          "트립닷닷 입력창에 링크 붙여넣기",
-          "‘최저가 링크 찾기’ 클릭"
+          "Trip.com에서 <strong>원하는 호텔/항공 상품 선택</strong>",
+          "해당 상품 주소창 <strong>링크 복사</strong>",
+          "트립닷닷 입력창에 <strong>링크 붙여넣기</strong>",
+          "‘<strong>최저가 링크 찾기</strong>’ 클릭"
         ]
       },
       ja: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "使い方",
         button: "OK",
         steps: [
-          "Trip.comで宿泊/航空ページを開く",
-          "そのページのURLをコピーする",
-          "Tripdotdotの入力欄に貼り付ける",
-          "「最安値リンクを探す」をクリック"
+          "Trip.comで<strong>宿泊/航空ページを開く</strong>",
+          "そのページのURLを<strong>コピーする</strong>",
+          "Tripdotdotの入力欄に<strong>貼り付ける</strong>",
+          "「<strong>最安値リンクを探す</strong>」をクリック"
         ]
       },
       th: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "วิธีใช้",
         button: "เข้าใจแล้ว",
         steps: [
-          "เปิดหน้าโรงแรม/ตั๋วเครื่องบินใน Trip.com",
-          "คัดลอกลิงก์ (URL) ของหน้านั้น",
-          "วางลิงก์ในช่องของ Tripdotdot",
-          "กด “ค้นหาลิงก์ราคาต่ำสุด”"
+          "ใน Trip.com <strong>เปิดหน้าโรงแรม/ตั๋วเครื่องบิน</strong>",
+          "<strong>คัดลอกลิงก์ (URL)</strong> ของหน้านั้น",
+          "ที่ Tripdotdot <strong>วางลิงก์</strong>",
+          "กด “<strong>ค้นหาลิงก์ราคาต่ำสุด</strong>”"
         ]
       },
       en: {
-        logo: "Tripdotdot",
+        logo: "🌐 Tripdotdot",
         title: "How to use",
         button: "Got it",
         steps: [
-          "Open the hotel/flight page on Trip.com",
-          "Copy the page URL from the address bar",
-          "Paste the URL into Tripdotdot",
-          "Click “Find lowest price”"
+          "On Trip.com, <strong>choose your hotel/flight</strong>",
+          "<strong>Copy the link</strong> from the address bar",
+          "In Tripdotdot, <strong>paste the link</strong>",
+          "Click “<strong>Find lowest price</strong>”"
         ]
       }
     };
@@ -313,7 +315,12 @@
         num.className = "num";
         num.textContent = (idx + 1).toString();
         li.appendChild(num);
-        li.appendChild(document.createTextNode(txt));
+
+        const textSpan = document.createElement("span");
+        textSpan.className = "step-text";
+        textSpan.innerHTML = txt;
+        li.appendChild(textSpan);
+
         list.appendChild(li);
       });
     }


### PR DESCRIPTION
## Summary
- update the English, Japanese, and Thai trust panels to use the same savings metrics structure as Korean
- refresh locale strings so each language highlights the ₩100M+ savings, usage count, and supported countries consistently

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e33a0993c8331b5759b9e6bae19ae)