### PR TITLE
Add Google Ads conversion tracking to Korean page

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,13 @@
 
   <!-- GA4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7NKHHET1CP"></script>
-  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-7NKHHET1CP');</script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17711709260"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-7NKHHET1CP');gtag('config','AW-17711709260');</script>
+
+  <!-- Event snippet for 외부 클릭 conversion page -->
+  <script>
+    gtag('event','conversion',{'send_to':'AW-17711709260/aV7GCNjD97sbEMz4zP1B'});
+  </script>
 
   <!-- Google AdSense -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6227921544579562" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- load the Google Ads conversion tracking library on the Korean homepage
- configure gtag for the Google Ads conversion ID and trigger the conversion event snippet

## Testing
- not run (static site change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f2c98ba14833191150f530c4c3c8d)