### PR TITLE
Add GA4 measurement ID to localized pages

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -6,7 +6,8 @@
 
   <!-- GA4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7NKHHET1CP"></script>
-  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-7NKHHET1CP');</script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y00T1V6W91"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-7NKHHET1CP');gtag('config','G-Y00T1V6W91');</script>
 
   <!-- Google AdSense -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6227921544579562" crossorigin="anonymous"></script>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,8 @@
   <!-- GA4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7NKHHET1CP"></script>
   <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17711709260"></script>
-  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-7NKHHET1CP');gtag('config','AW-17711709260');</script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y00T1V6W91"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-7NKHHET1CP');gtag('config','G-Y00T1V6W91');gtag('config','AW-17711709260');</script>
 
   <!-- Event snippet for 외부 클릭 conversion page -->
   <script>

--- a/ja/index.html
+++ b/ja/index.html
@@ -41,10 +41,13 @@
 
   <!-- Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7NKHHET1CP"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y00T1V6W91"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date()); gtag('config','G-7NKHHET1CP');
+    gtag('js', new Date());
+    gtag('config','G-7NKHHET1CP');
+    gtag('config','G-Y00T1V6W91');
   </script>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6227921544579562" crossorigin="anonymous"></script>
   <script>

--- a/th/index.html
+++ b/th/index.html
@@ -6,7 +6,8 @@
 
   <!-- GA4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7NKHHET1CP"></script>
-  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-7NKHHET1CP');</script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y00T1V6W91"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-7NKHHET1CP');gtag('config','G-Y00T1V6W91');</script>
 
   <!-- Google AdSense -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6227921544579562" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- add the new GA4 measurement ID G-Y00T1V6W91 alongside the existing analytics scripts across all localized landing pages

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911f010f09083318583d8c879342cd9)