### PR TITLE
Show search instructions below redirect banner

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -412,23 +412,51 @@
     }
   }
 
-  // ===== 리디렉트 토스트 =====
-  let isRedirecting = false;
-  function redirectWithModal(affUrl, delayMs=800){
-    if (isRedirecting) return;
-    isRedirecting = true;
+  // ===== 리디렉트 토스트 =====
+  let isRedirecting = false;
+  function redirectWithModal(affUrl, delayMs=800){
+    if (isRedirecting) return;
+    isRedirecting = true;
     const modal = $('#redirect-modal');
     if (modal) modal.style.display = 'flex';
     setTimeout(() => {
       if (modal) modal.style.display = 'none';
       window.open(affUrl, '_blank', 'noopener');
-      isRedirecting = false;
-    }, delayMs);
-  }
+      isRedirecting = false;
+    }, delayMs);
+  }
 
-  // ===== 단축링크 안내 카드 =====
-  function renderShortlinkNotice(rawUrl, container){
-    container.innerHTML = '';
+  function renderRedirectGuideCard(container, tripUrl){
+    if (!container) return;
+    container.innerHTML = '';
+
+    const card = document.createElement('div');
+    card.className = 'redirect-guide-card';
+
+    const title = document.createElement('div');
+    title.className = 'redirect-guide-card__title';
+    title.textContent = TL('redirecting');
+
+    const desc = document.createElement('div');
+    desc.className = 'redirect-guide-card__body';
+    desc.innerHTML = TL('redirectGuide') || '';
+
+    const link = document.createElement('a');
+    link.className = 'redirect-guide-card__cta';
+    link.href = tripUrl || '#';
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = TL('redirectingToSearch') || TL('searchPrompt');
+
+    card.appendChild(title);
+    card.appendChild(desc);
+    card.appendChild(link);
+    container.appendChild(card);
+  }
+
+  // ===== 단축링크 안내 카드 =====
+  function renderShortlinkNotice(rawUrl, container){
+    container.innerHTML = '';
 
     const card = document.createElement('div');
     card.className = 'info-card';
@@ -591,8 +619,10 @@
     // ===============================================
     if (!isUrl) {
       const affiliateHome = getAffiliateHomeUrl();
-      resultsDiv.innerHTML = `<p style="text-align:center; font-weight:bold;">${TL('redirecting')}</p>`;
-      redirectWithModal(affiliateHome, 800);
+      renderRedirectGuideCard(resultsDiv, affiliateHome);
+      try {
+        window.open(affiliateHome, '_blank', 'noopener');
+      } catch(_) {}
       return;
     }
     // ===============================================

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -647,6 +647,49 @@ footer p{ margin:3px 0; }
 }
 #redirect-modal .redirect-guide-list li{ line-height:1.5; }
 
+.redirect-guide-card{
+  background:#f4f7fb;
+  border:1px solid #dbe7f5;
+  border-radius:16px;
+  padding:16px;
+  max-width:720px;
+  margin:0 auto;
+  box-shadow:0 10px 30px rgba(0,0,0,0.04);
+  text-align:left;
+}
+.redirect-guide-card__title{
+  font-size:18px;
+  font-weight:700;
+  margin-bottom:8px;
+  color:#0b3b73;
+}
+.redirect-guide-card__body{
+  color:#243b53;
+  line-height:1.6;
+  font-size:14px;
+}
+.redirect-guide-card__body .redirect-guide-list{
+  margin-top:6px;
+  padding-left:18px;
+}
+.redirect-guide-card__body .redirect-guide-list li{ margin-bottom:4px; }
+.redirect-guide-card__cta{
+  display:inline-block;
+  margin-top:12px;
+  padding:10px 14px;
+  background:#0f6cf2;
+  color:#fff;
+  font-weight:700;
+  border-radius:10px;
+  text-decoration:none;
+  box-shadow:0 10px 20px rgba(15,108,242,0.15);
+  transition:transform 0.15s ease, box-shadow 0.15s ease;
+}
+.redirect-guide-card__cta:hover{
+  transform:translateY(-1px);
+  box-shadow:0 12px 24px rgba(15,108,242,0.2);
+}
+
 /* ===== Ads guide popup ===== */
 #ad-guide-popup .ad-guide-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary
- add on-page guidance card when users submit a search term instead of a Trip.com link
- open Trip.com in a new tab while keeping the step-by-step instructions visible on Tripdotdot
- style the new guidance card to match the site aesthetics

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69245d7ab12083318e2053ce71f2f297)