### PR TITLE
Improve search-mode guidance card styling

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -426,31 +426,44 @@
     }, delayMs);
   }
 
-  function renderRedirectGuideCard(container, tripUrl){
+  function renderRedirectGuideCard(container, tripUrl, options={}){
     if (!container) return;
     container.innerHTML = '';
 
     const card = document.createElement('div');
     card.className = 'redirect-guide-card';
 
+    const header = document.createElement('div');
+    header.className = 'redirect-guide-card__header';
+
+    const icon = document.createElement('span');
+    icon.className = 'redirect-guide-card__icon';
+    icon.textContent = options.icon || '🔗';
+
     const title = document.createElement('div');
     title.className = 'redirect-guide-card__title';
-    title.textContent = TL('redirecting');
+    title.textContent = options.titleText || TL('redirecting');
+
+    header.appendChild(icon);
+    header.appendChild(title);
 
     const desc = document.createElement('div');
     desc.className = 'redirect-guide-card__body';
-    desc.innerHTML = TL('redirectGuide') || '';
+    desc.innerHTML = options.guideHtml || TL('redirectGuide') || '';
 
-    const link = document.createElement('a');
-    link.className = 'redirect-guide-card__cta';
-    link.href = tripUrl || '#';
-    link.target = '_blank';
-    link.rel = 'noopener noreferrer';
-    link.textContent = TL('redirectingToSearch') || TL('searchPrompt');
-
-    card.appendChild(title);
+    card.appendChild(header);
     card.appendChild(desc);
-    card.appendChild(link);
+
+    if (options.showCta !== false) {
+      const link = document.createElement('a');
+      link.className = 'redirect-guide-card__cta';
+      link.href = tripUrl || '#';
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.textContent = options.ctaLabel || TL('redirectingToSearch') || TL('searchPrompt');
+      card.appendChild(link);
+    }
+
     container.appendChild(card);
   }
 
@@ -619,7 +632,12 @@
     // ===============================================
     if (!isUrl) {
       const affiliateHome = getAffiliateHomeUrl();
-      renderRedirectGuideCard(resultsDiv, affiliateHome);
+      renderRedirectGuideCard(resultsDiv, affiliateHome, {
+        icon: '🌍',
+        titleText: TL('searchModeTitle') || TL('redirecting'),
+        guideHtml: TL('searchModeGuide') || TL('redirectGuide'),
+        ctaLabel: TL('redirectingToSearch') || TL('searchPrompt')
+      });
       try {
         window.open(affiliateHome, '_blank', 'noopener');
       } catch(_) {}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -648,46 +648,71 @@ footer p{ margin:3px 0; }
 #redirect-modal .redirect-guide-list li{ line-height:1.5; }
 
 .redirect-guide-card{
-  background:#f4f7fb;
-  border:1px solid #dbe7f5;
-  border-radius:16px;
-  padding:16px;
+  background:linear-gradient(135deg, #f7fbff 0%, #eef3ff 100%);
+  border:1px solid #d9e6ff;
+  border-radius:18px;
+  padding:18px 18px 20px;
   max-width:720px;
   margin:0 auto;
-  box-shadow:0 10px 30px rgba(0,0,0,0.04);
+  box-shadow:0 12px 28px rgba(10, 68, 140, 0.08);
   text-align:left;
+}
+.redirect-guide-card__header{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  margin-bottom:10px;
+}
+.redirect-guide-card__icon{
+  width:38px;
+  height:38px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  border-radius:12px;
+  background:rgba(15,108,242,0.12);
+  color:#0f6cf2;
+  font-size:20px;
 }
 .redirect-guide-card__title{
   font-size:18px;
-  font-weight:700;
-  margin-bottom:8px;
+  font-weight:800;
   color:#0b3b73;
 }
 .redirect-guide-card__body{
-  color:#243b53;
-  line-height:1.6;
-  font-size:14px;
+  color:#1f2937;
+  line-height:1.7;
+  font-size:14.5px;
+}
+.redirect-guide-lead{
+  margin:0 0 8px;
+  font-weight:600;
+  color:#0f172a;
 }
 .redirect-guide-card__body .redirect-guide-list{
-  margin-top:6px;
-  padding-left:18px;
+  margin:0;
+  padding-left:20px;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
 }
-.redirect-guide-card__body .redirect-guide-list li{ margin-bottom:4px; }
+.redirect-guide-card__body .redirect-guide-list.redirect-guide-list--compact{ gap:8px; }
+.redirect-guide-card__body .redirect-guide-list li{ line-height:1.6; word-break:keep-all; }
 .redirect-guide-card__cta{
   display:inline-block;
-  margin-top:12px;
-  padding:10px 14px;
-  background:#0f6cf2;
+  margin-top:14px;
+  padding:11px 16px;
+  background:linear-gradient(120deg,#0f6cf2,#3b82f6);
   color:#fff;
-  font-weight:700;
-  border-radius:10px;
+  font-weight:750;
+  border-radius:12px;
   text-decoration:none;
-  box-shadow:0 10px 20px rgba(15,108,242,0.15);
+  box-shadow:0 14px 24px rgba(15,108,242,0.18);
   transition:transform 0.15s ease, box-shadow 0.15s ease;
 }
 .redirect-guide-card__cta:hover{
   transform:translateY(-1px);
-  box-shadow:0 12px 24px rgba(15,108,242,0.2);
+  box-shadow:0 16px 28px rgba(15,108,242,0.22);
 }
 
 /* ===== Ads guide popup ===== */

--- a/i18n/translations.js
+++ b/i18n/translations.js
@@ -33,6 +33,8 @@ window.TRANSLATIONS = {
     mobileNotice:`<p class="notice-icon">✨</p><p class="notice-text">For more accurate price comparison,<br><strong>use the PC (Desktop site) version!</strong><br><small>(Some prices may be the same across countries on mobile)</small></p>`,
     youtube:"YouTube", blog:"Blog",
     redirecting:"Redirecting to Trip.com...",
+    searchModeTitle:"How to fetch a Trip.com link",
+    searchModeGuide:`<p class="redirect-guide-lead">We detected a search term. Please follow these steps on Trip.com to grab the actual link:</p><ol class="redirect-guide-list redirect-guide-list--compact"><li>On Trip.com, search for the hotel or product you want (e.g., “Osaka Hilton”).</li><li>Select your travel dates and number of guests.</li><li>Press the search button to view the results.</li><li>Copy the results page URL and paste it back into Tripdotdot.</li></ol>`,
     redirectGuide:`<ol class="redirect-guide-list"><li>On the Trip.com page that opens, type your destination or hotel name (e.g., "Osaka Hilton").</li><li>Enter your travel dates.</li><li>Press search.</li><li>Copy the results page URL and paste it back into Tripdotdot.</li></ol>`,
 
     trustTitle:"Save more on travel costs",
@@ -83,6 +85,8 @@ window.TRANSLATIONS = {
     mobileNotice:`<p class="notice-icon">✨</p><p class="notice-text"><strong>더 정확한 최저가 비교는<br>PC(데스크톱 사이트)에서 가능해요!</strong><br><small>(일부 상품은 모바일에서 국가별 가격이 동일해요)</small></p>`,
     youtube:"YouTube", blog:"Blog",
     redirecting:"트립닷컴으로 이동합니다...",
+    searchModeTitle:"트립닷닷 이용 안내",
+    searchModeGuide:`<p class="redirect-guide-lead">검색어가 입력되었습니다. 아래 순서대로 트립닷컴에서 실제 링크를 가져와 주세요:</p><ol class="redirect-guide-list redirect-guide-list--compact"><li>트립닷컴에서 “오사카 힐튼”처럼 원하는 호텔/상품을 검색</li><li>여행 날짜와 인원 등을 선택</li><li>검색 버튼을 눌러 결과 페이지 확인</li><li>검색 결과 페이지의 URL을 복사해 다시 트립닷닷 입력창에 붙여넣기</li></ol>`,
     redirectGuide:`<ol class="redirect-guide-list"><li><strong>연결된 트립닷컴</strong> 홈페이지에서 원하는 숙소/상품을 검색하세요. (예: "오사카 힐튼")</li><li>여행 일정/숙박 기간을 입력</li><li>검색</li><li>검색 결과 페이지 주소를 복사해서 트립닷닷에 붙여넣기</li></ol>`,
 
     trustTitle:"여행 비용을 더 아껴보세요",
@@ -133,6 +137,8 @@ window.TRANSLATIONS = {
     mobileNotice:`<p class="notice-icon">✨</p><p class="notice-text"><strong>より正確な価格比較は<br>PC（デスクトップサイト）で可能です！</strong><br><small>（一部の商品はモバイルで各国の価格が同じです）</small></p>`,
     youtube:"YouTube", blog:"ブログ",
     redirecting:"Trip.comに移動します...",
+    searchModeTitle:"Trip.comリンクの取り方",
+    searchModeGuide:`<p class="redirect-guide-lead">検索キーワードが入力されました。Trip.comで実際のリンクを取得する手順です：</p><ol class="redirect-guide-list redirect-guide-list--compact"><li>Trip.comで「大阪 ヒルトン」のように希望のホテル/商品を検索</li><li>旅行日程や人数などを選択</li><li>検索ボタンを押して結果を確認</li><li>検索結果ページのURLをコピーし、Tripdotdotの入力欄に貼り付け</li></ol>`,
     redirectGuide:`<ol class="redirect-guide-list"><li>開いたTrip.comのトップで行き先/ホテル名を入力（例：「大阪 ヒルトン」）。</li><li>宿泊日程や旅行日を入力。</li><li>検索を押す。</li><li>表示された検索結果ページのURLをコピーし、Tripdotdotに貼り付け。</li></ol>`,
 
     trustTitle:"旅費をもっと節約しましょう",
@@ -183,6 +189,8 @@ window.TRANSLATIONS = {
     mobileNotice:`<p class="notice-icon">✨</p><p class="notice-text">เพื่อการเปรียบเทียบราคาที่แม่นยำกว่า<br><strong>แนะนำให้ใช้งานบนพีซี (Desktop)</strong><br><small>(บนมือถือ บางรายการอาจมีราคาเท่ากันทุกประเทศ)</small></p>`,
     youtube:"YouTube", blog:"บล็อก",
     redirecting:"กำลังพาไปที่ Trip.com...",
+    searchModeTitle:"วิธีนำลิงก์จาก Trip.com",
+    searchModeGuide:`<p class="redirect-guide-lead">ตรวจพบคำค้นหาแล้ว ทำตามขั้นตอนด้านล่างเพื่อดึงลิงก์จริงจาก Trip.com:</p><ol class="redirect-guide-list redirect-guide-list--compact"><li>ที่ Trip.com ค้นหาโรงแรมหรือสินค้าที่ต้องการ (เช่น “Osaka Hilton”)</li><li>เลือกวันที่เดินทางและจำนวนผู้เข้าพัก</li><li>กดปุ่มค้นหาเพื่อดูผลลัพธ์</li><li>คัดลอก URL ของหน้าผลการค้นหา แล้วนำมาวางในช่องกรอกของ Tripdotdot</li></ol>`,
     redirectGuide:`<ol class="redirect-guide-list"><li>หน้า Trip.com ที่เปิดขึ้น ให้พิมพ์จุดหมายหรือชื่อโรงแรม (เช่น “Osaka Hilton”)</li><li>ใส่วันที่เดินทางหรือเข้าพัก</li><li>กดค้นหา</li><li>คัดลอก URL ของหน้าผลการค้นหาแล้วกลับมาวางที่ Tripdotdot</li></ol>`,
 
     trustTitle:"ประหยัดค่าเดินทางได้มากขึ้น",


### PR DESCRIPTION
## Summary
- display search-term guidance directly in the redirect guide card using always-visible copy instead of transient popups
- refresh the Trip.com guide card styling with a gradient background, icon header, and tightened list spacing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692466ae2ab08331955f96f4264cdc6e)