### PR TITLE
Update Korean placeholder copy for Trip.com input

### DIFF
--- a/i18n/translations.js
+++ b/i18n/translations.js
@@ -64,7 +64,7 @@ window.TRANSLATIONS = {
     featureAutomationDesc:"국가별로 다른 할인 코드와 제휴 파라미터를 알아서 붙여줘요.",
     featureLanguageTitle:"다국어 완전 지원",
     featureLanguageDesc:"한국어·영어·일본어·태국어 UI로 누구나 쉽게 공유할 수 있어요.",
-    placeholder:"트립닷컴에서 날짜 선택 후 나온 링크를 붙여넣어 주세요!",
+    placeholder:"https://kr.trip.com/hotels/detail/~~ 로 바꿔",
     findButton:"최저가 링크 찾기",
     searchPrompt:"링크가 없다면? 여기서 검색하기",
     hotelTabTitle:"🏨 호텔 예약",

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
           <p class="hero-subtitle" data-lang="subtitle">트립닷컴 최저가 링크 찾기</p>
         </div>
         <div class="hero-input input-section">
-          <input id="inputUrl" data-lang-placeholder placeholder="트립닷컴에서 날짜 선택 후 나온 링크를 붙여넣어 주세요!" type="text"
+          <input id="inputUrl" data-lang-placeholder placeholder="https://kr.trip.com/hotels/detail/~~ 로 바꿔" type="text"
             inputmode="url">
           <div class="input-actions">
             <button class="main-button" onclick="generateLinks()" data-lang="findButton">최저가 링크 찾기</button>


### PR DESCRIPTION
## Summary
- update the homepage input placeholder to show the desired Trip.com hotels detail URL format
- align the Korean translation placeholder string with the new copy

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926f816e7608331a175ab3190574ac7)