### PR TITLE
Simplify ad-guide popup close control

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -790,37 +790,6 @@ footer p{ margin:3px 0; }
   font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
 }
 
-.ad-guide-close {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-  width: 36px;
-  height: 36px;
-  border-radius: 10px;
-  border: 1px solid rgba(15, 98, 254, 0.2);
-  background: #f8fafc;
-  color: #0f172a;
-  font-size: 20px;
-  font-weight: 800;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 8px 16px rgba(15, 98, 254, 0.12);
-  transition: transform 0.12s ease, box-shadow 0.2s ease, opacity 0.2s ease;
-}
-
-.ad-guide-close:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(15, 98, 254, 0.16);
-  opacity: 0.92;
-}
-
-.ad-guide-close:focus-visible {
-  outline: 2px solid #0f62fe;
-  outline-offset: 2px;
-}
-
 
 .ad-guide-header {
   display: flex;
@@ -861,26 +830,23 @@ footer p{ margin:3px 0; }
 
 .ad-guide-dismiss {
   margin-left: auto;
-  width: 40px;
-  height: 40px;
-  border-radius: 10px;
-  border: 1px solid rgba(15, 98, 254, 0.2);
-  background: #f8fafc;
-  color: #0f172a;
-  font-size: 20px;
-  font-weight: 800;
+  padding: 4px;
+  border: none;
+  background: transparent;
+  color: #94a3b8;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 8px 16px rgba(15, 98, 254, 0.12);
-  transition: transform 0.12s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  transition: color 0.2s ease, opacity 0.2s ease;
 }
 
 .ad-guide-dismiss:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(15, 98, 254, 0.16);
-  opacity: 0.92;
+  color: #64748b;
+  opacity: 0.9;
 }
 
 .ad-guide-dismiss:focus-visible {

--- a/en/index.html
+++ b/en/index.html
@@ -66,17 +66,13 @@
   <div id="ad-guide-popup" style="display:none;">
     <div class="ad-guide-overlay"></div>
     <div class="ad-guide-box">
-      <button id="ad-guide-close" class="ad-guide-close" type="button" aria-label="">
-        <span aria-hidden="true">×</span>
-      </button>
       <div class="ad-guide-header">
         <div class="ad-guide-heading">
           <span class="ad-guide-logo"></span>
           <span class="ad-guide-title"></span>
         </div>
-        <button id="ad-guide-dismiss" class="ad-guide-emoji" type="button">
-          <span class="ad-guide-emoji__icon">✈️</span>
-          <span class="ad-guide-emoji__close" aria-hidden="true">×</span>
+        <button id="ad-guide-dismiss" class="ad-guide-dismiss" type="button" aria-label="">
+          <span class="ad-guide-dismiss__icon" aria-hidden="true">×</span>
         </button>
       </div>
       <ul id="ad-guide-list" class="ad-guide-list"></ul>
@@ -358,9 +354,6 @@
       const dismiss = popup.querySelector("#ad-guide-dismiss");
       if (dismiss) dismiss.setAttribute("aria-label", t.closeLabel);
 
-      const closeBtn = popup.querySelector("#ad-guide-close");
-      if (closeBtn) closeBtn.setAttribute("aria-label", t.closeLabel);
-
       const list = document.getElementById("ad-guide-list");
       list.innerHTML = "";
       t.steps.forEach((txt, idx) => {
@@ -397,9 +390,11 @@
       const popup = document.getElementById("ad-guide-popup");
       const closePopup = () => popup.style.display = "none";
 
-      popup.querySelector("#ad-guide-dismiss").onclick = closePopup;
-      popup.querySelector("#ad-guide-close").onclick = closePopup;
-      popup.querySelector(".ad-guide-overlay").onclick = closePopup;
+      const dismissButton = popup.querySelector("#ad-guide-dismiss");
+      if (dismissButton) dismissButton.onclick = closePopup;
+
+      const overlay = popup.querySelector(".ad-guide-overlay");
+      if (overlay) overlay.onclick = closePopup;
     });
   </script>
 

--- a/index.html
+++ b/index.html
@@ -242,15 +242,12 @@
   <div id="ad-guide-popup" style="display:none;">
     <div class="ad-guide-overlay"></div>
     <div class="ad-guide-box">
-      <button id="ad-guide-close" class="ad-guide-close" type="button" aria-label="">
-        <span aria-hidden="true">×</span>
-      </button>
       <div class="ad-guide-header">
         <div class="ad-guide-heading">
           <span class="ad-guide-logo"></span>
           <span class="ad-guide-title"></span>
         </div>
-        <button id="ad-guide-dismiss" class="ad-guide-dismiss" type="button">
+        <button id="ad-guide-dismiss" class="ad-guide-dismiss" type="button" aria-label="">
           <span class="ad-guide-dismiss__icon" aria-hidden="true">×</span>
         </button>
       </div>
@@ -369,9 +366,6 @@
       const dismiss = popup.querySelector("#ad-guide-dismiss");
       if (dismiss) dismiss.setAttribute("aria-label", t.closeLabel);
 
-      const closeBtn = popup.querySelector("#ad-guide-close");
-      if (closeBtn) closeBtn.setAttribute("aria-label", t.closeLabel);
-
       const list = document.getElementById("ad-guide-list");
       list.innerHTML = "";
       t.steps.forEach((txt, idx) => {
@@ -416,9 +410,11 @@
       const popup = document.getElementById("ad-guide-popup");
       const closePopup = () => popup.style.display = "none";
 
-      popup.querySelector("#ad-guide-dismiss").onclick = closePopup;
-      popup.querySelector("#ad-guide-close").onclick = closePopup;
-      popup.querySelector(".ad-guide-overlay").onclick = closePopup;
+      const dismissButton = popup.querySelector("#ad-guide-dismiss");
+      if (dismissButton) dismissButton.onclick = closePopup;
+
+      const overlay = popup.querySelector(".ad-guide-overlay");
+      if (overlay) overlay.onclick = closePopup;
 
       const ctaButton = popup.querySelector("#ad-guide-cta");
       if (ctaButton) ctaButton.addEventListener("click", trackAdGuideCtaClick);

--- a/ja/index.html
+++ b/ja/index.html
@@ -85,17 +85,13 @@
   <div id="ad-guide-popup" style="display:none;">
     <div class="ad-guide-overlay"></div>
     <div class="ad-guide-box">
-      <button id="ad-guide-close" class="ad-guide-close" type="button" aria-label="">
-        <span aria-hidden="true">×</span>
-      </button>
       <div class="ad-guide-header">
         <div class="ad-guide-heading">
           <span class="ad-guide-logo"></span>
           <span class="ad-guide-title"></span>
         </div>
-        <button id="ad-guide-dismiss" class="ad-guide-emoji" type="button">
-          <span class="ad-guide-emoji__icon">✈️</span>
-          <span class="ad-guide-emoji__close" aria-hidden="true">×</span>
+        <button id="ad-guide-dismiss" class="ad-guide-dismiss" type="button" aria-label="">
+          <span class="ad-guide-dismiss__icon" aria-hidden="true">×</span>
         </button>
       </div>
       <ul id="ad-guide-list" class="ad-guide-list"></ul>
@@ -383,9 +379,6 @@
       const dismiss = popup.querySelector("#ad-guide-dismiss");
       if (dismiss) dismiss.setAttribute("aria-label", t.closeLabel);
 
-      const closeBtn = popup.querySelector("#ad-guide-close");
-      if (closeBtn) closeBtn.setAttribute("aria-label", t.closeLabel);
-
       const list = document.getElementById("ad-guide-list");
       list.innerHTML = "";
       t.steps.forEach((txt, idx) => {
@@ -422,9 +415,11 @@
       const popup = document.getElementById("ad-guide-popup");
       const closePopup = () => popup.style.display = "none";
 
-      popup.querySelector("#ad-guide-dismiss").onclick = closePopup;
-      popup.querySelector("#ad-guide-close").onclick = closePopup;
-      popup.querySelector(".ad-guide-overlay").onclick = closePopup;
+      const dismissButton = popup.querySelector("#ad-guide-dismiss");
+      if (dismissButton) dismissButton.onclick = closePopup;
+
+      const overlay = popup.querySelector(".ad-guide-overlay");
+      if (overlay) overlay.onclick = closePopup;
     });
   </script>
 

--- a/th/index.html
+++ b/th/index.html
@@ -67,17 +67,13 @@
   <div id="ad-guide-popup" style="display:none;">
     <div class="ad-guide-overlay"></div>
     <div class="ad-guide-box">
-      <button id="ad-guide-close" class="ad-guide-close" type="button" aria-label="">
-        <span aria-hidden="true">×</span>
-      </button>
       <div class="ad-guide-header">
         <div class="ad-guide-heading">
           <span class="ad-guide-logo"></span>
           <span class="ad-guide-title"></span>
         </div>
-        <button id="ad-guide-dismiss" class="ad-guide-emoji" type="button">
-          <span class="ad-guide-emoji__icon">✈️</span>
-          <span class="ad-guide-emoji__close" aria-hidden="true">×</span>
+        <button id="ad-guide-dismiss" class="ad-guide-dismiss" type="button" aria-label="">
+          <span class="ad-guide-dismiss__icon" aria-hidden="true">×</span>
         </button>
       </div>
       <ul id="ad-guide-list" class="ad-guide-list"></ul>
@@ -359,9 +355,6 @@
       const dismiss = popup.querySelector("#ad-guide-dismiss");
       if (dismiss) dismiss.setAttribute("aria-label", t.closeLabel);
 
-      const closeBtn = popup.querySelector("#ad-guide-close");
-      if (closeBtn) closeBtn.setAttribute("aria-label", t.closeLabel);
-
       const list = document.getElementById("ad-guide-list");
       list.innerHTML = "";
       t.steps.forEach((txt, idx) => {
@@ -398,9 +391,11 @@
       const popup = document.getElementById("ad-guide-popup");
       const closePopup = () => popup.style.display = "none";
 
-      popup.querySelector("#ad-guide-dismiss").onclick = closePopup;
-      popup.querySelector("#ad-guide-close").onclick = closePopup;
-      popup.querySelector(".ad-guide-overlay").onclick = closePopup;
+      const dismissButton = popup.querySelector("#ad-guide-dismiss");
+      if (dismissButton) dismissButton.onclick = closePopup;
+
+      const overlay = popup.querySelector(".ad-guide-overlay");
+      if (overlay) overlay.onclick = closePopup;
     });
   </script>
 


### PR DESCRIPTION
## Summary
- remove redundant floating close button from ad-guide popup across locales
- restyle the remaining dismiss icon to be smaller, borderless, and lighter
## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937af6ab4008331be4ebce4c27913e7)