### PR TITLE
Update ad guide popup close controls

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -917,6 +917,29 @@ footer p{ margin:3px 0; }
   font-size: 1.05rem;
 }
 
+.ad-guide-secondary-btn {
+  width: 100%;
+  margin-top: 10px;
+  background: #f8fafc;
+  color: #0f62fe;
+  border: 1px solid #dbeafe;
+  border-radius: 12px;
+  padding: 11px 0 12px;
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.ad-guide-secondary-btn:hover {
+  background: #eff6ff;
+  border-color: #bfdbfe;
+}
+
 /* ===== Responsive ===== */
 @media (max-width:600px){
   /* 모바일에서 언어 버튼이 카드에 잘리지 않도록 살짝 안쪽으로 배치 */

--- a/en/index.html
+++ b/en/index.html
@@ -71,15 +71,13 @@
           <span class="ad-guide-logo"></span>
           <span class="ad-guide-title"></span>
         </div>
-        <button id="ad-guide-dismiss" class="ad-guide-dismiss" type="button" aria-label="">
-          <span class="ad-guide-dismiss__icon" aria-hidden="true">×</span>
-        </button>
       </div>
       <ul id="ad-guide-list" class="ad-guide-list"></ul>
       <a id="ad-guide-cta" class="ad-guide-btn" target="_blank" rel="noopener">
         <span class="ad-guide-btn__icon" aria-hidden="true">↗</span>
         <span class="ad-guide-btn__text"></span>
       </a>
+      <button id="ad-guide-close" class="ad-guide-secondary-btn" type="button"></button>
     </div>
   </div>
 
@@ -289,6 +287,7 @@
         logo: "🌐 Tripdotdot",
         title: "How to use",
         cta: "원하는 상품 찾기",
+        secondaryCta: "트립닷컴 링크가 있어요",
         closeLabel: "Hide popup",
         steps: [
           "On Trip.com, <strong>choose your hotel/flight</strong>",
@@ -351,8 +350,11 @@
         cta.href = getAffiliateHomeUrlForPopup(lang);
       }
 
-      const dismiss = popup.querySelector("#ad-guide-dismiss");
-      if (dismiss) dismiss.setAttribute("aria-label", t.closeLabel);
+      const closeBtn = popup.querySelector("#ad-guide-close");
+      if (closeBtn) {
+        closeBtn.textContent = t.secondaryCta || t.closeLabel;
+        closeBtn.setAttribute("aria-label", t.closeLabel);
+      }
 
       const list = document.getElementById("ad-guide-list");
       list.innerHTML = "";
@@ -390,8 +392,8 @@
       const popup = document.getElementById("ad-guide-popup");
       const closePopup = () => popup.style.display = "none";
 
-      const dismissButton = popup.querySelector("#ad-guide-dismiss");
-      if (dismissButton) dismissButton.onclick = closePopup;
+      const closeButton = popup.querySelector("#ad-guide-close");
+      if (closeButton) closeButton.onclick = closePopup;
 
       const overlay = popup.querySelector(".ad-guide-overlay");
       if (overlay) overlay.onclick = closePopup;

--- a/index.html
+++ b/index.html
@@ -247,15 +247,13 @@
           <span class="ad-guide-logo"></span>
           <span class="ad-guide-title"></span>
         </div>
-        <button id="ad-guide-dismiss" class="ad-guide-dismiss" type="button" aria-label="">
-          <span class="ad-guide-dismiss__icon" aria-hidden="true">×</span>
-        </button>
       </div>
       <ul id="ad-guide-list" class="ad-guide-list"></ul>
       <a id="ad-guide-cta" class="ad-guide-btn" target="_blank" rel="noopener">
         <span class="ad-guide-btn__icon" aria-hidden="true">↗</span>
         <span class="ad-guide-btn__text"></span>
       </a>
+      <button id="ad-guide-close" class="ad-guide-secondary-btn" type="button"></button>
     </div>
   </div>
 
@@ -265,6 +263,7 @@
         logo: "🌐 트립닷닷",
         title: "사용법",
         cta: "원하는 상품 찾기",
+        secondaryCta: "트립닷컴 링크가 있어요",
         closeLabel: "팝업 숨기기",
         steps: [
           "Trip.com에서 <strong>원하는 호텔/항공 상품 선택</strong>",
@@ -277,6 +276,7 @@
         logo: "🌐 Tripdotdot",
         title: "使い方",
         cta: "원하는 상품 찾기",
+        secondaryCta: "트립닷컴 링크가 있어요",
         closeLabel: "ポップアップを非表示にする",
         steps: [
           "Trip.comで<strong>宿泊/航空ページを開く</strong>",
@@ -289,6 +289,7 @@
         logo: "🌐 Tripdotdot",
         title: "วิธีใช้",
         cta: "원하는 상품 찾기",
+        secondaryCta: "트립닷컴 링크가 있어요",
         closeLabel: "ซ่อนป๊อปอัพ",
         steps: [
           "ใน Trip.com <strong>เปิดหน้าโรงแรม/ตั๋วเครื่องบิน</strong>",
@@ -301,6 +302,7 @@
         logo: "🌐 Tripdotdot",
         title: "How to use",
         cta: "원하는 상품 찾기",
+        secondaryCta: "트립닷컴 링크가 있어요",
         closeLabel: "Hide popup",
         steps: [
           "On Trip.com, <strong>choose your hotel/flight</strong>",
@@ -363,8 +365,11 @@
         cta.href = getAffiliateHomeUrlForPopup(lang);
       }
 
-      const dismiss = popup.querySelector("#ad-guide-dismiss");
-      if (dismiss) dismiss.setAttribute("aria-label", t.closeLabel);
+      const closeBtn = popup.querySelector("#ad-guide-close");
+      if (closeBtn) {
+        closeBtn.textContent = t.secondaryCta || t.closeLabel;
+        closeBtn.setAttribute("aria-label", t.closeLabel);
+      }
 
       const list = document.getElementById("ad-guide-list");
       list.innerHTML = "";
@@ -410,8 +415,8 @@
       const popup = document.getElementById("ad-guide-popup");
       const closePopup = () => popup.style.display = "none";
 
-      const dismissButton = popup.querySelector("#ad-guide-dismiss");
-      if (dismissButton) dismissButton.onclick = closePopup;
+      const closeButton = popup.querySelector("#ad-guide-close");
+      if (closeButton) closeButton.onclick = closePopup;
 
       const overlay = popup.querySelector(".ad-guide-overlay");
       if (overlay) overlay.onclick = closePopup;

--- a/ja/index.html
+++ b/ja/index.html
@@ -90,15 +90,13 @@
           <span class="ad-guide-logo"></span>
           <span class="ad-guide-title"></span>
         </div>
-        <button id="ad-guide-dismiss" class="ad-guide-dismiss" type="button" aria-label="">
-          <span class="ad-guide-dismiss__icon" aria-hidden="true">×</span>
-        </button>
       </div>
       <ul id="ad-guide-list" class="ad-guide-list"></ul>
       <a id="ad-guide-cta" class="ad-guide-btn" target="_blank" rel="noopener">
         <span class="ad-guide-btn__icon" aria-hidden="true">↗</span>
         <span class="ad-guide-btn__text"></span>
       </a>
+      <button id="ad-guide-close" class="ad-guide-secondary-btn" type="button"></button>
     </div>
   </div>
 
@@ -290,6 +288,7 @@
         logo: "🌐 Tripdotdot",
         title: "使い方",
         cta: "원하는 상품 찾기",
+        secondaryCta: "트립닷컴 링크가 있어요",
         closeLabel: "ポップアップを非表示にする",
         steps: [
           "Trip.comで<strong>宿泊/航空ページを開く</strong>",
@@ -376,8 +375,11 @@
         cta.href = getAffiliateHomeUrlForPopup(lang);
       }
 
-      const dismiss = popup.querySelector("#ad-guide-dismiss");
-      if (dismiss) dismiss.setAttribute("aria-label", t.closeLabel);
+      const closeBtn = popup.querySelector("#ad-guide-close");
+      if (closeBtn) {
+        closeBtn.textContent = t.secondaryCta || t.closeLabel;
+        closeBtn.setAttribute("aria-label", t.closeLabel);
+      }
 
       const list = document.getElementById("ad-guide-list");
       list.innerHTML = "";
@@ -415,8 +417,8 @@
       const popup = document.getElementById("ad-guide-popup");
       const closePopup = () => popup.style.display = "none";
 
-      const dismissButton = popup.querySelector("#ad-guide-dismiss");
-      if (dismissButton) dismissButton.onclick = closePopup;
+      const closeButton = popup.querySelector("#ad-guide-close");
+      if (closeButton) closeButton.onclick = closePopup;
 
       const overlay = popup.querySelector(".ad-guide-overlay");
       if (overlay) overlay.onclick = closePopup;

--- a/th/index.html
+++ b/th/index.html
@@ -72,15 +72,13 @@
           <span class="ad-guide-logo"></span>
           <span class="ad-guide-title"></span>
         </div>
-        <button id="ad-guide-dismiss" class="ad-guide-dismiss" type="button" aria-label="">
-          <span class="ad-guide-dismiss__icon" aria-hidden="true">×</span>
-        </button>
       </div>
       <ul id="ad-guide-list" class="ad-guide-list"></ul>
       <a id="ad-guide-cta" class="ad-guide-btn" target="_blank" rel="noopener">
         <span class="ad-guide-btn__icon" aria-hidden="true">↗</span>
         <span class="ad-guide-btn__text"></span>
       </a>
+      <button id="ad-guide-close" class="ad-guide-secondary-btn" type="button"></button>
     </div>
   </div>
 
@@ -278,6 +276,7 @@
         logo: "🌐 Tripdotdot",
         title: "วิธีใช้",
         cta: "원하는 상품 찾기",
+        secondaryCta: "트립닷컴 링크가 있어요",
         closeLabel: "ซ่อนป๊อปอัพ",
         steps: [
           "ใน Trip.com <strong>เปิดหน้าโรงแรม/ตั๋วเครื่องบิน</strong>",
@@ -352,8 +351,11 @@
         cta.href = getAffiliateHomeUrlForPopup(lang);
       }
 
-      const dismiss = popup.querySelector("#ad-guide-dismiss");
-      if (dismiss) dismiss.setAttribute("aria-label", t.closeLabel);
+      const closeBtn = popup.querySelector("#ad-guide-close");
+      if (closeBtn) {
+        closeBtn.textContent = t.secondaryCta || t.closeLabel;
+        closeBtn.setAttribute("aria-label", t.closeLabel);
+      }
 
       const list = document.getElementById("ad-guide-list");
       list.innerHTML = "";
@@ -391,8 +393,8 @@
       const popup = document.getElementById("ad-guide-popup");
       const closePopup = () => popup.style.display = "none";
 
-      const dismissButton = popup.querySelector("#ad-guide-dismiss");
-      if (dismissButton) dismissButton.onclick = closePopup;
+      const closeButton = popup.querySelector("#ad-guide-close");
+      if (closeButton) closeButton.onclick = closePopup;
 
       const overlay = popup.querySelector(".ad-guide-overlay");
       if (overlay) overlay.onclick = closePopup;


### PR DESCRIPTION
## Summary
- remove the header X close control from the ad guide popup and add a new close button beneath the primary CTA across locales
- set localized popup text to use the new "트립닷컴 링크가 있어요" close action and keep overlay dismissal
- style the new secondary close button for visual separation under the main blue button

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938d3f2d7ac8331875da64badfcfeb1)