### PR TITLE
Simplify unsupported domain prompt

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -626,21 +626,6 @@
           hostNote.textContent = `${T.unsupportedDomainDetected || 'Detected domain'}: ${host}`;
           desc.appendChild(hostNote);
         } catch (_) {}
-
-        const note = document.createElement('p');
-        note.className = 'redirect-guide-card__note';
-        try {
-          const link = document.createElement('a');
-          link.href = new URL(rawUrl).toString();
-          link.target = '_blank';
-          link.rel = 'noopener noreferrer';
-          link.textContent = rawUrl;
-          link.className = 'redirect-guide-card__note-link';
-          note.appendChild(link);
-        } catch (_) {
-          note.textContent = rawUrl;
-        }
-        desc.appendChild(note);
       }
     }
 
@@ -656,20 +641,6 @@
       tripBtn.rel = 'noopener noreferrer';
       tripBtn.textContent = T.unsupportedDomainCta || TL('searchModeCta') || 'Open Trip.com';
       actions.appendChild(tripBtn);
-
-      if (rawUrl) {
-        try {
-          const parsed = new URL(rawUrl);
-          const rawLink = document.createElement('a');
-          rawLink.className = 'redirect-guide-card__cta redirect-guide-card__cta--ghost';
-          rawLink.href = parsed.toString();
-          rawLink.target = '_blank';
-          rawLink.rel = 'noopener noreferrer';
-          rawLink.textContent = T.unsupportedDomainOpenOriginal || 'View the link you pasted';
-          rawLink.title = parsed.toString();
-          actions.appendChild(rawLink);
-        } catch (_) {}
-      }
 
       card.appendChild(actions);
     }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -721,7 +721,7 @@ footer p{ margin:3px 0; }
 #redirect-modal .redirect-guide-list li{ line-height:1.5; }
 
 .redirect-guide-card{
-  background:linear-gradient(135deg, #f7fbff 0%, #eef3ff 100%);
+  background:#fff;
   border:1px solid #d9e6ff;
   border-radius:18px;
   padding:18px 18px 20px;
@@ -795,12 +795,15 @@ footer p{ margin:3px 0; }
   text-decoration:none;
   box-shadow:0 14px 24px rgba(50,100,255,.2);
   transition:transform 0.15s ease, box-shadow 0.15s ease;
+  min-width: 240px;
+  text-align: center;
 }
 .redirect-guide-card__actions{
   display:flex;
   gap:10px;
   flex-wrap:wrap;
   margin-top:16px;
+  justify-content:center;
 }
 .redirect-guide-card__cta--ghost{
   background:#fff;


### PR DESCRIPTION
## Summary
- remove pasted-link display and open-original button from the unsupported domain guidance
- adjust the unsupported domain card styling to use a white background and center a wider Trip.com button

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693acfe132908331a26869d7d1566243)