### PR TITLE
Add device-aware affiliate parameters

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -306,14 +306,30 @@
       return "ko";
     }
 
-    const AFF_AFFIX = "Allianceid=6624731&SID=225753893&trip_sub1=&trip_sub3=D4136351";
+    const DEFAULT_AFF_AFFIX = "Allianceid=6624731&SID=225753893&trip_sub1=&trip_sub3=D4136351";
+    const AFFILIATE_AFFIX_MAP = {
+      ko: {
+        desktop: "Allianceid=6624731&SID=225753893&trip_sub1=kr_pc&trip_sub3=D4136351",
+        mobile: "Allianceid=6624731&SID=225753893&trip_sub1=kr_mobile&trip_sub3=D8377686"
+      },
+      ja: {
+        desktop: "Allianceid=6624731&SID=225753893&trip_sub1=jp_pc&trip_sub3=D8322736",
+        mobile: "Allianceid=6624731&SID=225753893&trip_sub1=jp_mobile&trip_sub3=D8377749"
+      }
+    };
+    const isMobileDevice = () => /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 
-    function appendAffiliate(urlStr) {
+    function getAffiliateAffix(lang = getCurrentLang(), deviceIsMobile = isMobileDevice()) {
+      const affixByLang = AFFILIATE_AFFIX_MAP[lang];
+      if (!affixByLang) return DEFAULT_AFF_AFFIX;
+      return (deviceIsMobile ? affixByLang.mobile : affixByLang.desktop) || DEFAULT_AFF_AFFIX;
+    }
+    function appendAffiliate(urlStr, lang = getCurrentLang()) {
       try {
         const u = new URL(urlStr, location.origin);
         const sp = u.searchParams;
         if (!sp.has("Allianceid") && !sp.has("SID")) {
-          AFF_AFFIX.split("&").forEach(kv => {
+          getAffiliateAffix(lang).split("&").forEach(kv => {
             const [k, v = ""] = kv.split("=");
             if (!sp.has(k)) sp.set(k, v);
           });
@@ -321,7 +337,7 @@
         }
         return u.toString();
       } catch (_) {
-        return urlStr + (urlStr.includes("?") ? "&" : "?") + AFF_AFFIX;
+        return urlStr + (urlStr.includes("?") ? "&" : "?") + getAffiliateAffix(lang);
       }
     }
 
@@ -331,7 +347,7 @@
         (lang === "ja") ? "https://www.trip.com/?curr=JPY" :
         (lang === "th") ? "https://www.trip.com/?curr=THB" :
                           "https://www.trip.com/?curr=USD";
-      return appendAffiliate(base);
+      return appendAffiliate(base, lang);
     }
 
     function renderAdGuidePopup() {

--- a/index.html
+++ b/index.html
@@ -321,14 +321,30 @@
       return "ko";
     }
 
-    const AFF_AFFIX = "Allianceid=6624731&SID=225753893&trip_sub1=&trip_sub3=D4136351";
+    const DEFAULT_AFF_AFFIX = "Allianceid=6624731&SID=225753893&trip_sub1=&trip_sub3=D4136351";
+    const AFFILIATE_AFFIX_MAP = {
+      ko: {
+        desktop: "Allianceid=6624731&SID=225753893&trip_sub1=kr_pc&trip_sub3=D4136351",
+        mobile: "Allianceid=6624731&SID=225753893&trip_sub1=kr_mobile&trip_sub3=D8377686"
+      },
+      ja: {
+        desktop: "Allianceid=6624731&SID=225753893&trip_sub1=jp_pc&trip_sub3=D8322736",
+        mobile: "Allianceid=6624731&SID=225753893&trip_sub1=jp_mobile&trip_sub3=D8377749"
+      }
+    };
+    const isMobileDevice = () => /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 
-    function appendAffiliate(urlStr) {
+    function getAffiliateAffix(lang = getCurrentLang(), deviceIsMobile = isMobileDevice()) {
+      const affixByLang = AFFILIATE_AFFIX_MAP[lang];
+      if (!affixByLang) return DEFAULT_AFF_AFFIX;
+      return (deviceIsMobile ? affixByLang.mobile : affixByLang.desktop) || DEFAULT_AFF_AFFIX;
+    }
+    function appendAffiliate(urlStr, lang = getCurrentLang()) {
       try {
         const u = new URL(urlStr, location.origin);
         const sp = u.searchParams;
         if (!sp.has("Allianceid") && !sp.has("SID")) {
-          AFF_AFFIX.split("&").forEach(kv => {
+          getAffiliateAffix(lang).split("&").forEach(kv => {
             const [k, v = ""] = kv.split("=");
             if (!sp.has(k)) sp.set(k, v);
           });
@@ -336,7 +352,7 @@
         }
         return u.toString();
       } catch (_) {
-        return urlStr + (urlStr.includes("?") ? "&" : "?") + AFF_AFFIX;
+        return urlStr + (urlStr.includes("?") ? "&" : "?") + getAffiliateAffix(lang);
       }
     }
 
@@ -346,7 +362,7 @@
         (lang === "ja") ? "https://www.trip.com/?curr=JPY" :
         (lang === "th") ? "https://www.trip.com/?curr=THB" :
                           "https://www.trip.com/?curr=USD";
-      return appendAffiliate(base);
+      return appendAffiliate(base, lang);
     }
 
     function renderAdGuidePopup() {

--- a/ja/index.html
+++ b/ja/index.html
@@ -330,14 +330,30 @@
       return "ko";
     }
 
-    const AFF_AFFIX = "Allianceid=6624731&SID=225753893&trip_sub1=&trip_sub3=D4136351";
+    const DEFAULT_AFF_AFFIX = "Allianceid=6624731&SID=225753893&trip_sub1=&trip_sub3=D4136351";
+    const AFFILIATE_AFFIX_MAP = {
+      ko: {
+        desktop: "Allianceid=6624731&SID=225753893&trip_sub1=kr_pc&trip_sub3=D4136351",
+        mobile: "Allianceid=6624731&SID=225753893&trip_sub1=kr_mobile&trip_sub3=D8377686"
+      },
+      ja: {
+        desktop: "Allianceid=6624731&SID=225753893&trip_sub1=jp_pc&trip_sub3=D8322736",
+        mobile: "Allianceid=6624731&SID=225753893&trip_sub1=jp_mobile&trip_sub3=D8377749"
+      }
+    };
+    const isMobileDevice = () => /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 
-    function appendAffiliate(urlStr) {
+    function getAffiliateAffix(lang = getCurrentLang(), deviceIsMobile = isMobileDevice()) {
+      const affixByLang = AFFILIATE_AFFIX_MAP[lang];
+      if (!affixByLang) return DEFAULT_AFF_AFFIX;
+      return (deviceIsMobile ? affixByLang.mobile : affixByLang.desktop) || DEFAULT_AFF_AFFIX;
+    }
+    function appendAffiliate(urlStr, lang = getCurrentLang()) {
       try {
         const u = new URL(urlStr, location.origin);
         const sp = u.searchParams;
         if (!sp.has("Allianceid") && !sp.has("SID")) {
-          AFF_AFFIX.split("&").forEach(kv => {
+          getAffiliateAffix(lang).split("&").forEach(kv => {
             const [k, v = ""] = kv.split("=");
             if (!sp.has(k)) sp.set(k, v);
           });
@@ -345,7 +361,7 @@
         }
         return u.toString();
       } catch (_) {
-        return urlStr + (urlStr.includes("?") ? "&" : "?") + AFF_AFFIX;
+        return urlStr + (urlStr.includes("?") ? "&" : "?") + getAffiliateAffix(lang);
       }
     }
 
@@ -355,7 +371,7 @@
         (lang === "ja") ? "https://www.trip.com/?curr=JPY" :
         (lang === "th") ? "https://www.trip.com/?curr=THB" :
                           "https://www.trip.com/?curr=USD";
-      return appendAffiliate(base);
+      return appendAffiliate(base, lang);
     }
 
     function renderAdGuidePopup() {

--- a/th/index.html
+++ b/th/index.html
@@ -307,14 +307,30 @@
       return "ko";
     }
 
-    const AFF_AFFIX = "Allianceid=6624731&SID=225753893&trip_sub1=&trip_sub3=D4136351";
+    const DEFAULT_AFF_AFFIX = "Allianceid=6624731&SID=225753893&trip_sub1=&trip_sub3=D4136351";
+    const AFFILIATE_AFFIX_MAP = {
+      ko: {
+        desktop: "Allianceid=6624731&SID=225753893&trip_sub1=kr_pc&trip_sub3=D4136351",
+        mobile: "Allianceid=6624731&SID=225753893&trip_sub1=kr_mobile&trip_sub3=D8377686"
+      },
+      ja: {
+        desktop: "Allianceid=6624731&SID=225753893&trip_sub1=jp_pc&trip_sub3=D8322736",
+        mobile: "Allianceid=6624731&SID=225753893&trip_sub1=jp_mobile&trip_sub3=D8377749"
+      }
+    };
+    const isMobileDevice = () => /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 
-    function appendAffiliate(urlStr) {
+    function getAffiliateAffix(lang = getCurrentLang(), deviceIsMobile = isMobileDevice()) {
+      const affixByLang = AFFILIATE_AFFIX_MAP[lang];
+      if (!affixByLang) return DEFAULT_AFF_AFFIX;
+      return (deviceIsMobile ? affixByLang.mobile : affixByLang.desktop) || DEFAULT_AFF_AFFIX;
+    }
+    function appendAffiliate(urlStr, lang = getCurrentLang()) {
       try {
         const u = new URL(urlStr, location.origin);
         const sp = u.searchParams;
         if (!sp.has("Allianceid") && !sp.has("SID")) {
-          AFF_AFFIX.split("&").forEach(kv => {
+          getAffiliateAffix(lang).split("&").forEach(kv => {
             const [k, v = ""] = kv.split("=");
             if (!sp.has(k)) sp.set(k, v);
           });
@@ -322,7 +338,7 @@
         }
         return u.toString();
       } catch (_) {
-        return urlStr + (urlStr.includes("?") ? "&" : "?") + AFF_AFFIX;
+        return urlStr + (urlStr.includes("?") ? "&" : "?") + getAffiliateAffix(lang);
       }
     }
 
@@ -332,7 +348,7 @@
         (lang === "ja") ? "https://www.trip.com/?curr=JPY" :
         (lang === "th") ? "https://www.trip.com/?curr=THB" :
                           "https://www.trip.com/?curr=USD";
-      return appendAffiliate(base);
+      return appendAffiliate(base, lang);
     }
 
     function renderAdGuidePopup() {


### PR DESCRIPTION
## Summary
- add device- and locale-specific affiliate parameter mappings for Trip.com links
- update affiliate app logic and inline popup scripts to use the new mapping
- default to legacy affiliate parameters for other locales when no mapping exists

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d858190b883319717b731109617a2)