### PR TITLE
Update English and Thai UI copy for compliance

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tripdotdot | Trip.com Lowest Price Link Finder</title>
+  <title>Tripdotdot | Global Hotel & Flight Price Comparator</title>
 
   <!-- GA4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7NKHHET1CP"></script>
@@ -26,13 +26,13 @@
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
   <meta name="googlebot" content="index,follow,max-image-preview:large,max-snippet:-1">
   <meta name="author" content="tripdotdot">
-  <meta name="keywords" content="Tripdotdot, Trip.com, lowest price, price comparison, hotels, flights, packages, coupon, promo code, voucher code, discount code, Trip.com discount code, Trip.com discount code September, Trip.com discount code October">
-  <meta name="description" content="Tripdotdot — Compare Trip.com prices across up to 21 country sites and generate country-specific links to book at the lowest price. Save in seconds and travel now.">
+  <meta name="keywords" content="Tripdotdot, lowest price, price comparison, hotels, flights, packages, coupon, promo code, voucher code, discount code, travel discount code, hotel discount code September, flight discount code October">
+  <meta name="description" content="Tripdotdot — Compare booking prices across up to 21 country sites and generate country-specific links to book at the lowest price. Save in seconds and travel now.">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Tripdotdot | Trip.com Lowest Price Link Finder">
+  <meta property="og:title" content="Tripdotdot | Global Hotel & Flight Price Comparator">
   <meta property="og:site_name" content="Tripdotdot">
-  <meta property="og:description" content="Compare Trip.com prices by country and get discount-ready links. Find the lowest price across up to 21 sites and save instantly.">
+  <meta property="og:description" content="Compare booking prices by country and get discount-ready links. Find the lowest price across up to 21 sites and save instantly.">
   <meta property="og:image" content="https://tripdotdot.com/thumbnail.jpg">
   <meta property="og:url" content="https://tripdotdot.com/en/">
   <meta property="og:type" content="website">
@@ -95,13 +95,13 @@
 
         <div class="hero-copy">
           <h1 data-lang="mainTitle">🌐 Tripdotdot</h1>
-          <p class="hero-subtitle" data-lang="subtitle">Trip.com Lowest Price Link Finder</p>
+          <p class="hero-subtitle" data-lang="subtitle">Global Hotel & Flight Price Comparator</p>
         </div>
         <div class="hero-input input-section">
-          <input id="inputUrl" data-lang-placeholder placeholder="Paste the Trip.com link after selecting your dates!" type="text" inputmode="url">
+          <input id="inputUrl" data-lang-placeholder placeholder="Paste the booking link after selecting your dates!" type="text" inputmode="url">
           <div class="input-actions">
             <button class="main-button" onclick="generateLinks()" data-lang="findButton">Find Lowest Price Links</button>
-            <button id="show-widget-button" class="secondary-button" data-lang="searchPrompt">No link yet? Search on Trip.com</button>
+            <button id="show-widget-button" class="secondary-button" data-lang="searchPrompt">No link yet? Search on a booking site</button>
           </div>
         </div>
       </div>
@@ -125,7 +125,7 @@
           </div>
         </div>
         <ul data-lang="card2List">
-          <li>1️⃣ On Trip.com, choose your hotel/flight, enter <strong>stay or travel dates</strong>, then copy the URL.</li>
+          <li>1️⃣ Search for a hotel/flight product, enter <strong>stay or travel dates</strong>, then copy the URL.</li>
           <li>2️⃣ Paste that link above and press <strong>'Find'</strong>.</li>
           <li>3️⃣ Click the generated links to <strong>find the best price!</strong></li>
         </ul>
@@ -133,7 +133,7 @@
 
       <section class="info-card highlight-card">
         <h2 data-lang="card1Title">🌍 Find the Cheapest Country</h2>
-        <p data-lang="card1Desc">Trip.com prices can <strong>differ by country.</strong><br>Use <strong>Tripdotdot</strong> to book at the <span class="highlight">absolute lowest price!</span></p>
+        <p data-lang="card1Desc">Booking prices can <strong>differ by country.</strong><br>Use <strong>Tripdotdot</strong> to book at the <span class="highlight">absolute lowest price!</span></p>
       </section>
 
       <section class="info-card">
@@ -211,9 +211,9 @@
   </div>
 
   <!-- Center toast -->
-  <div id="redirect-modal" role="dialog" aria-live="polite" aria-label="Trip.com redirect notice">
+  <div id="redirect-modal" role="dialog" aria-live="polite" aria-label="Booking site redirect notice">
     <div class="redirect-box">
-      <div class="redirect-title" data-lang="redirecting">Redirecting to Trip.com...</div>
+      <div class="redirect-title" data-lang="redirecting">Redirecting to the booking site...</div>
       <div class="redirect-guide" data-lang="redirectGuide"></div>
     </div>
   </div>
@@ -253,7 +253,7 @@
         cta: "원하는 상품 찾기",
         closeLabel: "팝업 숨기기",
         steps: [
-          "Trip.com에서 <strong>원하는 호텔/항공 상품 선택</strong>",
+          "트립닷컴에서 <strong>원하는 호텔/항공 상품 선택</strong>",
           "해당 상품 주소창 <strong>링크 복사</strong>",
           "트립닷닷 입력창에 <strong>링크 붙여넣기</strong>",
           "‘<strong>최저가 링크 찾기</strong>’ 클릭"
@@ -265,7 +265,7 @@
         cta: "원하는 상품 찾기",
         closeLabel: "ポップアップを非表示にする",
         steps: [
-          "Trip.comで<strong>宿泊/航空ページを開く</strong>",
+          "トリップドットコムで<strong>宿泊/航空ページを開く</strong>",
           "そのページのURLを<strong>コピーする</strong>",
           "Tripdotdotの入力欄に<strong>貼り付ける</strong>",
           "「<strong>最安値リンクを探す</strong>」をクリック"
@@ -277,7 +277,7 @@
         cta: "원하는 상품 찾기",
         closeLabel: "ซ่อนป๊อปอัพ",
         steps: [
-          "ใน Trip.com <strong>เปิดหน้าโรงแรม/ตั๋วเครื่องบิน</strong>",
+          "ใน ทริปดอทคอม <strong>เปิดหน้าโรงแรม/ตั๋วเครื่องบิน</strong>",
           "<strong>คัดลอกลิงก์ (URL)</strong> ของหน้านั้น",
           "ที่ Tripdotdot <strong>วางลิงก์</strong>",
           "กด “<strong>ค้นหาลิงก์ราคาต่ำสุด</strong>”"
@@ -290,7 +290,7 @@
         secondaryCta: "트립닷컴 링크가 있어요",
         closeLabel: "Hide popup",
         steps: [
-          "On Trip.com, <strong>choose your hotel/flight</strong>",
+          "On a booking site, <strong>choose your hotel/flight</strong>",
           "<strong>Copy the link</strong> from the address bar",
           "In Tripdotdot, <strong>paste the link</strong>",
           "Click “<strong>Find lowest price</strong>”"

--- a/th/index.html
+++ b/th/index.html
@@ -2,7 +2,7 @@
 <html lang="th">
 <head>
   <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tripdotdot | ค้นหาลิงก์ราคาถูกสุดของ Trip.com</title>
+  <title>Tripdotdot | ค้นหาลิงก์ราคาถูกสุดของ ทริปดอทคอม</title>
 
   <!-- GA4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7NKHHET1CP"></script>
@@ -26,13 +26,13 @@
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
   <meta name="googlebot" content="index,follow,max-image-preview:large,max-snippet:-1">
   <meta name="author" content="tripdotdot">
-  <meta name="keywords" content="Tripdotdot, Trip.com, ราคาถูก, เปรียบเทียบราคา, โรงแรม, ตั๋วเครื่องบิน, แพ็กเกจ, คูปอง, โค้ดส่วนลด, โค้ดโปรโมชัน, Trip.com โค้ดส่วนลด, Trip.com ส่วนลด กันยายน, Trip.com ส่วนลด ตุลาคม">
-  <meta name="description" content="ลิงก์ส่วนลด Trip.com แยกตามประเทศ | ประหยัดทันที | เปรียบเทียบราคาถูกสุดได้สูงสุด 21 ประเทศ">
+  <meta name="keywords" content="Tripdotdot, ทริปดอทคอม, ราคาถูก, เปรียบเทียบราคา, โรงแรม, ตั๋วเครื่องบิน, แพ็กเกจ, คูปอง, โค้ดส่วนลด, โค้ดโปรโมชัน, โค้ดส่วนลดโรงแรม, โค้ดส่วนลดเที่ยวบิน กันยายน, โค้ดส่วนลดเที่ยวบิน ตุลาคม">
+  <meta name="description" content="ลิงก์ส่วนลด ทริปดอทคอม แยกตามประเทศ | ประหยัดทันที | เปรียบเทียบราคาถูกสุดได้สูงสุด 21 ประเทศ">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Tripdotdot | ค้นหาลิงก์ราคาถูกสุดของ Trip.com">
+  <meta property="og:title" content="Tripdotdot | ค้นหาลิงก์ราคาถูกสุดของ ทริปดอทคอม">
   <meta property="og:site_name" content="Tripdotdot">
-  <meta property="og:description" content="ลิงก์ส่วนลด Trip.com แยกตามประเทศ | ประหยัดทันที | เปรียบเทียบราคาถูกสุดได้สูงสุด 21 ประเทศ">
+  <meta property="og:description" content="ลิงก์ส่วนลด ทริปดอทคอม แยกตามประเทศ | ประหยัดทันที | เปรียบเทียบราคาถูกสุดได้สูงสุด 21 ประเทศ">
   <meta property="og:image" content="https://tripdotdot.com/thumbnail.jpg">
   <meta property="og:url" content="https://tripdotdot.com/th/">
   <meta property="og:type" content="website">
@@ -96,13 +96,13 @@
 
         <div class="hero-copy">
           <h1 data-lang="mainTitle">🌐 Tripdotdot</h1>
-          <p class="hero-subtitle" data-lang="subtitle">ค้นหาลิงก์ราคาถูกสุดของ Trip.com</p>
+          <p class="hero-subtitle" data-lang="subtitle">ค้นหาลิงก์ราคาถูกสุดของ ทริปดอทคอม</p>
         </div>
         <div class="hero-input input-section">
-          <input id="inputUrl" data-lang-placeholder placeholder="วางลิงก์ Trip.com หลังจากใส่วันที่เดินทางแล้ว" type="text" inputmode="url">
+          <input id="inputUrl" data-lang-placeholder placeholder="วางลิงก์ ทริปดอทคอม หลังจากใส่วันที่เดินทางแล้ว" type="text" inputmode="url">
           <div class="input-actions">
             <button class="main-button" onclick="generateLinks()" data-lang="findButton">ค้นหาลิงก์ราคาถูกสุด</button>
-            <button id="show-widget-button" class="secondary-button" data-lang="searchPrompt">ยังไม่มีลิงก์? ค้นหาบน Trip.com</button>
+            <button id="show-widget-button" class="secondary-button" data-lang="searchPrompt">ยังไม่มีลิงก์? ค้นหาบน ทริปดอทคอม</button>
           </div>
         </div>
       </div>
@@ -126,7 +126,7 @@
           </div>
         </div>
         <ul data-lang="card2List">
-          <li>1️⃣ บน Trip.com เลือกโรงแรม/เที่ยวบิน ใส่<strong>วันที่เข้าพักหรือเดินทาง</strong> แล้วคัดลอกลิงก์จากแถบที่อยู่</li>
+          <li>1️⃣ บน ทริปดอทคอม เลือกโรงแรม/เที่ยวบิน ใส่<strong>วันที่เข้าพักหรือเดินทาง</strong> แล้วคัดลอกลิงก์จากแถบที่อยู่</li>
           <li>2️⃣ วางลิงก์ด้านบนแล้วกด<strong>‘ค้นหา’</strong></li>
           <li>3️⃣ คลิกลิงก์ประเทศที่สร้าง เพื่อ<strong>ดูราคาดีที่สุด</strong></li>
         </ul>
@@ -134,7 +134,7 @@
 
       <section class="info-card highlight-card">
         <h2 data-lang="card1Title">🌍 หาประเทศที่ถูกที่สุด</h2>
-        <p data-lang="card1Desc">ราคาบน Trip.com <strong>อาจต่างกันตามประเทศ</strong><br>ใช้ <strong>Tripdotdot</strong> เพื่อจองใน <span class="highlight">ราคาต่ำสุด!</span></p>
+        <p data-lang="card1Desc">ราคาบน ทริปดอทคอม <strong>อาจต่างกันตามประเทศ</strong><br>ใช้ <strong>Tripdotdot</strong> เพื่อจองใน <span class="highlight">ราคาต่ำสุด!</span></p>
       </section>
 
       <section class="info-card">
@@ -212,9 +212,9 @@
   </div>
 
   <!-- Toast (center) -->
-  <div id="redirect-modal" role="dialog" aria-live="polite" aria-label="กำลังเชื่อมต่อ Trip.com">
+  <div id="redirect-modal" role="dialog" aria-live="polite" aria-label="กำลังเชื่อมต่อ ทริปดอทคอม">
     <div class="redirect-box">
-      <div class="redirect-title" data-lang="redirecting">กำลังไปที่ Trip.com...</div>
+      <div class="redirect-title" data-lang="redirecting">กำลังไปที่ ทริปดอทคอม...</div>
       <div class="redirect-guide" data-lang="redirectGuide"></div>
     </div>
   </div>
@@ -254,7 +254,7 @@
         cta: "원하는 상품 찾기",
         closeLabel: "팝업 숨기기",
         steps: [
-          "Trip.com에서 <strong>원하는 호텔/항공 상품 선택</strong>",
+          "트립닷컴에서 <strong>원하는 호텔/항공 상품 선택</strong>",
           "해당 상품 주소창 <strong>링크 복사</strong>",
           "트립닷닷 입력창에 <strong>링크 붙여넣기</strong>",
           "‘<strong>최저가 링크 찾기</strong>’ 클릭"
@@ -266,7 +266,7 @@
         cta: "원하는 상품 찾기",
         closeLabel: "ポップアップを非表示にする",
         steps: [
-          "Trip.comで<strong>宿泊/航空ページを開く</strong>",
+          "トリップドットコムで<strong>宿泊/航空ページを開く</strong>",
           "そのページのURLを<strong>コピーする</strong>",
           "Tripdotdotの入力欄に<strong>貼り付ける</strong>",
           "「<strong>最安値リンクを探す</strong>」をクリック"
@@ -279,7 +279,7 @@
         secondaryCta: "트립닷컴 링크가 있어요",
         closeLabel: "ซ่อนป๊อปอัพ",
         steps: [
-          "ใน Trip.com <strong>เปิดหน้าโรงแรม/ตั๋วเครื่องบิน</strong>",
+          "ใน ทริปดอทคอม <strong>เปิดหน้าโรงแรม/ตั๋วเครื่องบิน</strong>",
           "<strong>คัดลอกลิงก์ (URL)</strong> ของหน้านั้น",
           "ที่ Tripdotdot <strong>วางลิงก์</strong>",
           "กด “<strong>ค้นหาลิงก์ราคาต่ำสุด</strong>”"
@@ -291,7 +291,7 @@
         cta: "원하는 상품 찾기",
         closeLabel: "Hide popup",
         steps: [
-          "On Trip.com, <strong>choose your hotel/flight</strong>",
+          "On a booking site, <strong>choose your hotel/flight</strong>",
           "<strong>Copy the link</strong> from the address bar",
           "In Tripdotdot, <strong>paste the link</strong>",
           "Click “<strong>Find lowest price</strong>”"


### PR DESCRIPTION
## Summary
- Replace English hero, placeholder, instructions, and redirect copy with generic booking-site language
- Update Thai hero, placeholder, instructions, and redirect copy to use the Thai transliteration of the brand name
- Refresh English and Thai metadata to align with the new copy

## Testing
- Not run (static content changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942c03322208331b4118c77cd805af1)