### PR TITLE
Simplify logo button styling

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -117,16 +117,12 @@ footer p{ margin:3px 0; }
   text-decoration:none;
   font-size:inherit;
   font-weight:700;
-  box-shadow:
-    0 14px 28px rgba(17,24,39,.08),
-    inset 0 1px 0 rgba(255,255,255,.9);
+  box-shadow:none;
   transition:transform .18s ease, box-shadow .18s ease, border-color .18s ease;
-  backdrop-filter:blur(2px);
+  backdrop-filter:none;
 }
 .logo-button:hover{
-  box-shadow:
-    0 16px 34px rgba(17,24,39,.12),
-    inset 0 1px 0 rgba(255,255,255,1);
+  box-shadow:none;
   transform:translateY(-1px);
 }
 .logo-button:focus-visible{


### PR DESCRIPTION
## Summary
- remove the logo button box shadows and blur that caused a white highlight on light backgrounds
- retain the button layout while keeping hover movement without added styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947f02208a88331a07040ff9f85a6ba)