### PR TITLE
Remove Coupang ad placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,9 +150,7 @@
 
       <section class="info-card adsense-card desktop-only" aria-label="Tripdotdot 광고"
         style="display: flex; justify-content: center; align-items: center; min-height: 200px;">
-        <iframe
-          src="https://ads-partners.coupang.com/widgets.html?id=944280&template=carousel&trackingCode=AF1517522&subId=&width=336&height=200&tsource="
-          width="336" height="200" frameborder="0" scrolling="no" referrerpolicy="unsafe-url" browsingtopics></iframe>
+        
       </section>
     </div>
 


### PR DESCRIPTION
## Summary
- remove Coupang ad iframe from the desktop-only ad section to leave a blank placeholder area

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a24a12be883319363d4f1bfc1a928)