### PR TITLE
Move history section below country buttons

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -109,6 +109,8 @@
       </div>
     </header>
 
+    <div class="link-list" id="results"></div>
+
     <section class="history-section" id="history-section">
       <div class="history-header">
         <h2 data-lang="historyTitle">🕘 Recent links</h2>
@@ -119,8 +121,6 @@
         <div id="history-list" class="history-list" role="list"></div>
       </div>
     </section>
-
-    <div class="link-list" id="results"></div>
 
     <div class="info-grid">
       <section class="info-card usage-card">

--- a/index.html
+++ b/index.html
@@ -102,6 +102,8 @@
       </div>
     </header>
 
+    <div class="link-list" id="results"></div>
+
     <section class="history-section" id="history-section">
       <div class="history-header">
         <h2 data-lang="historyTitle">🕘 최근 본 링크</h2>
@@ -112,8 +114,6 @@
         <div id="history-list" class="history-list" role="list"></div>
       </div>
     </section>
-
-    <div class="link-list" id="results"></div>
 
     <div class="info-grid">
       <section class="info-card usage-card">

--- a/ja/index.html
+++ b/ja/index.html
@@ -128,6 +128,8 @@
       </div>
     </header>
 
+    <div class="link-list" id="results"></div>
+
     <section class="history-section" id="history-section">
       <div class="history-header">
         <h2 data-lang="historyTitle">🕘 最近のリンク</h2>
@@ -138,8 +140,6 @@
         <div id="history-list" class="history-list" role="list"></div>
       </div>
     </section>
-
-    <div class="link-list" id="results"></div>
 
     <div class="info-grid">
       <section class="info-card usage-card">

--- a/th/index.html
+++ b/th/index.html
@@ -110,6 +110,8 @@
       </div>
     </header>
 
+    <div class="link-list" id="results"></div>
+
     <section class="history-section" id="history-section">
       <div class="history-header">
         <h2 data-lang="historyTitle">🕘 ลิงก์ล่าสุด</h2>
@@ -120,8 +122,6 @@
         <div id="history-list" class="history-list" role="list"></div>
       </div>
     </section>
-
-    <div class="link-list" id="results"></div>
 
     <div class="info-grid">
       <section class="info-card usage-card">


### PR DESCRIPTION
## Summary
- move the recently viewed links section below the country link buttons so it appears after generated results
- keep layout consistent across Korean, English, Japanese, and Thai pages

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958cfd1ab30833197c5f461fb61724a)