### PR TITLE
Add maintenance overlay across locales

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1241,6 +1241,64 @@ html:lang(ja) .secondary-button{ font-size:14px; padding:13px 14px; }
   border-color: #bfdbfe;
 }
 
+/* ===== Maintenance Mode ===== */
+.maintenance-active {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #f8fafc, #e2e8f0);
+}
+
+.maintenance-active .container,
+.maintenance-active #ad-guide-popup {
+  display: none !important;
+}
+
+.maintenance-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 9999;
+}
+
+.maintenance-card {
+  max-width: 560px;
+  width: 100%;
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 32px;
+  text-align: center;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+  border: 1px solid #e2e8f0;
+}
+
+.maintenance-card h1 {
+  font-size: 28px;
+  margin: 0 0 12px;
+  color: #0f172a;
+}
+
+.maintenance-card p {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.6;
+  color: #475569;
+}
+
+.maintenance-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  color: #0f172a;
+  background: #f1f5f9;
+  border-radius: 999px;
+  padding: 6px 14px;
+  margin-bottom: 16px;
+}
+
 /* ===== Responsive ===== */
 @media (max-width:600px){
   /* 모바일에서 언어 버튼이 카드에 잘리지 않도록 살짝 안쪽으로 배치 */

--- a/en/index.html
+++ b/en/index.html
@@ -60,7 +60,14 @@
   }
   </script>
 </head>
-<body>
+<body class="maintenance-active">
+  <div class="maintenance-overlay" role="alert" aria-live="assertive">
+    <div class="maintenance-card">
+      <span class="maintenance-badge">🚧 Temporary Maintenance</span>
+      <h1>We&rsquo;re temporarily offline</h1>
+      <p>All services are paused while we perform maintenance. We&rsquo;ll be back soon.</p>
+    </div>
+  </div>
   <div id="ad-guide-popup" style="display:none;">
     <div class="ad-guide-overlay"></div>
     <div class="ad-guide-box">

--- a/index.html
+++ b/index.html
@@ -69,7 +69,14 @@
   </script>
 </head>
 
-<body>
+<body class="maintenance-active">
+  <div class="maintenance-overlay" role="alert" aria-live="assertive">
+    <div class="maintenance-card">
+      <span class="maintenance-badge">🚧 사이트 임시 중단</span>
+      <h1>현재 점검 중입니다</h1>
+      <p>모든 서비스가 일시적으로 중단되었습니다. 빠르게 정상화하겠습니다.</p>
+    </div>
+  </div>
   <div class="container">
     <header class="header">
       <div class="hero-surface">

--- a/th/index.html
+++ b/th/index.html
@@ -60,7 +60,14 @@
   }
   </script>
 </head>
-<body>
+<body class="maintenance-active">
+  <div class="maintenance-overlay" role="alert" aria-live="assertive">
+    <div class="maintenance-card">
+      <span class="maintenance-badge">🚧 ปิดให้บริการชั่วคราว</span>
+      <h1>กำลังปรับปรุงระบบ</h1>
+      <p>ขณะนี้ทุกบริการถูกระงับชั่วคราว เราจะกลับมาให้บริการอีกครั้งโดยเร็วที่สุด</p>
+    </div>
+  </div>
   <!-- Ads 유입자 안내 팝업 -->
   <div id="ad-guide-popup" style="display:none;">
     <div class="ad-guide-overlay"></div>


### PR DESCRIPTION
### Motivation
- Provide a global maintenance mode that shows a full-screen notice and prevents users from interacting with the application while work is ongoing.
- Ensure the maintenance notice is shown for all public homepage variants so any domain returns the same downtime message.
- Keep the main UI and ad popups hidden during maintenance to avoid exposing partial functionality.

### Description
- Added maintenance styles in `assets/styles.css` including `.maintenance-active`, `.maintenance-overlay`, and `.maintenance-card` to present a centered maintenance notice and hide the main UI.
- Enabled maintenance overlay markup and applied `class="maintenance-active"` to the `<body>` in `index.html`, `en/index.html`, and `th/index.html` with localized messages for Korean, English, and Thai.
- The CSS forces `display: none !important` for the primary `.container` and the `#ad-guide-popup` when maintenance is active so interactive elements are fully hidden.
- Kept the change limited to static HTML/CSS so it can be easily reverted or toggled in deployment.

### Testing
- Started a local server with `python -m http.server 8000` to serve the modified files, which successfully began serving content.
- Attempted to capture a screenshot with Playwright to validate the overlay, but the Playwright Chromium run crashed with a native SIGSEGV error so the screenshot step failed.
- No unit tests exist for this static change and no automated test suite was run against the markup/CSS beyond the above checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697749050aac8331b2fbb88e886e423a)